### PR TITLE
Quasi-free processes with pluto

### DIFF
--- a/data/ActiveHe3.dat
+++ b/data/ActiveHe3.dat
@@ -1,0 +1,29 @@
+## Active Target Parameters
+## JRMA 30th June 2020
+##
+## Vessel dimensions in mm
+## length main cell
+## radius main cell
+## wall thickness
+## upstream extension length
+## downstream extension length
+## extension inner radius
+## Be window thickness
+AT-Dim: 420.0 51.0 1.5 150.0 50.0 10.0 0.5
+##
+## Wavelength shifting plates
+## # segments in 2pi phi
+## plate thickness
+## radial clearance to main vessel side
+## lateral clearance to main vessel ends
+AT-WLS: 8 3.0 2.0 5.0
+##
+## Scintillation Yield (# photons/MeV)
+AT-Scint: 1000
+##
+## Run Mode 0=no, 1=yes
+## Check overlaps
+## Use WLS
+## Run optical photon tracking
+## Section main cell along length
+Run-Mode: 0 1 0 0

--- a/data/ActiveHe3.dat
+++ b/data/ActiveHe3.dat
@@ -19,11 +19,11 @@ AT-Dim: 420.0 51.0 1.5 150.0 50.0 10.0 0.5
 AT-WLS: 8 3.0 2.0 5.0
 ##
 ## Scintillation Yield (# photons/MeV)
-AT-Scint: 1000
+AT-Scint: 100
 ##
 ## Run Mode 0=no, 1=yes
 ## Check overlaps
 ## Use WLS
 ## Run optical photon tracking
 ## Section main cell along length
-Run-Mode: 0 1 0 0
+Run-Mode: 0 1 1 0

--- a/data/ActiveHe3.dat
+++ b/data/ActiveHe3.dat
@@ -16,8 +16,12 @@ AT-Dim: 420.0 51.0 1.5 150.0 50.0 10.0 0.5
 ## plate thickness
 ## radial clearance to main vessel side
 ## lateral clearance to main vessel ends
+# Plate
 #AT-WLS: 8 3.0 2.0 5.0
-AT-WLS: 40 6.0 0.0 5.0
+# Fiber
+#AT-WLS: 40 6.0 0.0 5.0
+# Helix
+AT-WLS: 60 0.5 5.0 5.0
 ##
 ## Scintillation Yield (# photons/MeV)
 AT-Scint: 65
@@ -28,4 +32,4 @@ AT-Scint: 65
 ## Run optical photon tracking
 ## Use TPB (instead of nitrogen for shifter)
 ## Section main cell along length
-Run-Mode: 0 2 1 1 0
+Run-Mode: 0 3 1 1 0

--- a/data/ActiveHe3.dat
+++ b/data/ActiveHe3.dat
@@ -16,14 +16,16 @@ AT-Dim: 420.0 51.0 1.5 150.0 50.0 10.0 0.5
 ## plate thickness
 ## radial clearance to main vessel side
 ## lateral clearance to main vessel ends
-AT-WLS: 8 3.0 2.0 5.0
+#AT-WLS: 8 3.0 2.0 5.0
+AT-WLS: 40 6.0 0.0 5.0
 ##
 ## Scintillation Yield (# photons/MeV)
-AT-Scint: 100
+AT-Scint: 65
 ##
 ## Run Mode 0=no, 1=yes
 ## Check overlaps
-## Use WLS
+## Use WLS (1: plate barrel, 2: fiber barrel, 3: fiber helix)
 ## Run optical photon tracking
+## Use TPB (instead of nitrogen for shifter)
 ## Section main cell along length
-Run-Mode: 0 1 1 0
+Run-Mode: 0 2 1 1 0

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -1,0 +1,164 @@
+// He3 gas scintillator active target
+// Original coding B.Strandberg 2013-2015
+// Modified for A2Geant-Master
+// J.R.M. Annand 18th June 2020
+// J.R.M. Annand 29th June 2020 Add WLS plates option
+//
+#ifndef A2ActiveHe3_h
+#define A2ActiveHe3_h 1
+
+//includes
+#include "A2Target.hh"
+#include "G4LogicalVolume.hh"
+#include "G4Material.hh"
+#include "G4MaterialPropertiesTable.hh"
+#include "G4NistManager.hh"
+
+
+class A2ActiveHe3: public A2Target
+{
+public:
+  
+  A2ActiveHe3();
+  ~A2ActiveHe3();
+
+  virtual G4VPhysicalVolume* Construct(G4LogicalVolume *MotherLogical, G4double=0);
+
+  //functions used with macros
+  void SetMakeMylarSections(G4int makesections) {fMakeMylarSections = makesections;}
+  void SetOpticalSimulation(G4int optsim) {fOpticalSimulation = optsim; }
+  G4int GetOpticalSimulation() { return fOpticalSimulation; }
+
+  void SetScintillationYield(G4double scintyield);
+
+  //used for communication with stepping action
+  void SetMakeEpoxy(G4bool makeepoxy) {fMakeEpoxy = makeepoxy;}
+  G4bool GetMakeEpoxy() {return fMakeEpoxy;}
+
+  //functions that build parts of the detector
+  void MakeVessel();
+  void MakeWLS();
+  void MakePCB();
+  void MakeTeflonLayer();
+  void MakeSiPMTs(){}
+  void MakeMylarSections(G4int nrofsections);
+  void DefineMaterials();
+  void SetOpticalProperties();
+  void SetIsOverlapVol(G4bool isOv){ fIsOverlapVol = isOv; }
+  void ReadParameters(const char*);
+
+  //this places all sub-parts into fMyLogic
+  void PlaceParts();
+  G4LogicalVolume* GetHeInsideTeflonLogic(){ return fHeInsideTeflonLogic; }
+
+private:
+
+  G4NistManager* fNistManager;
+  G4bool fIsOverlapVol;
+
+  //------------------------------------------------------------------------
+  //booleans controlling detector construction and simulation
+  //------------------------------------------------------------------------
+  G4int fMakeMylarSections;
+  G4int fOpticalSimulation;
+  G4bool fMakeEpoxy; //determine whether epoxy layer on top of pmt's is build or not
+  G4double fScintYield;
+  //
+  G4int fIsWLS;
+
+  //------------------------------------------------------------------------
+  //volumes
+  //------------------------------------------------------------------------
+  //Logical and physical volumes that are part of every detector class
+  G4LogicalVolume* fMotherLogic;        //Logical volume of the mother
+  G4LogicalVolume* fMyLogic;            //Logical Volume for this detector
+  G4VPhysicalVolume* fMyPhysi;          //Physical volume for this detector
+
+  //Logical volumes of this specific detector class
+  G4LogicalVolume* fVesselLogic;        //mother for Aluminum vessel and Be windows
+  G4LogicalVolume* fHeOutsideTeflonLogic; //mother to fPCMLogic
+  G4LogicalVolume* fWLSLogic;           //WLS plate logic
+  G4LogicalVolume* fPCBLogic;           //mother for Printed circuit board
+  G4LogicalVolume* fTeflonLogic;        //mother for Teflan cylinder and ends, mylar
+  G4LogicalVolume* fHeInsideTeflonLogic; //mother for pmt's and epoxy layers
+
+  G4LogicalVolume* fTeflonCylLogic;        //Teflan cylinder (need for optical properties)
+  G4LogicalVolume* fTeflonCylEndLogic;     //Teflan cylinder end (need for optical properties)
+  G4LogicalVolume* fPMTLogic;           //logic of single pmt cell (need for optical properties)
+  G4LogicalVolume* fEpoxyLogic;         //logic of the epoxy layer (need for optical properties)
+  G4LogicalVolume* fMylarLogic;         //logic of the Mylar window (need for optical properties)
+  G4LogicalVolume* fMylarSectionLogic;  //logic for the mylar section window inside main cell
+
+  G4VPhysicalVolume **fPMTPhysic;   //physical volumes to set LogicalBorderSurface
+  G4VPhysicalVolume **fEpoxyPhysic;
+  //------------------------------------------------------------------------
+  //geometric parameters
+  //------------------------------------------------------------------------
+
+  //geometric parameters for MakeVessel()
+  G4double fHeContainerR; //inner radius of the helium container
+  G4double fHeContainerZ; //length of the helium container
+  G4double fExtensionR; //inner radius of the extension tubes
+  G4double fExtensionZU; //length upstream extension tube
+  G4double fExtensionZD; //length downstream extension tube
+  G4double fContainerThickness; //thickness of the metal vessel
+  G4double fBeThickness; //thickness of the beryllium end windows
+
+  // geometric parameters for MakeWLS()
+  G4int fNwls;            // phi segmentation
+  G4double fWLSthick;     // plate thickness
+  G4double fRadClr;       // radial clearance to vessel
+  G4double fLatClr;       // lateral clearance to vessel
+  G4double fRwls1;        // radial pos. plate centre
+  
+  //geometric parameters for MakePCB()
+  G4double fPCBThickness; //thickness of the printed circuit board
+  G4double fPCBRadius;    //inner radius of the printed circuit board
+  G4double fPCBZ;         //length of th pcb
+
+  //geometric parameters for MakeTeflanLayer()
+  G4double fTeflonThicknessEnd;  //thickness of teflan at end walls
+  G4double fTeflonThicknessCyl;  //thickness of teflan covering the pcb cylinder
+  G4double fTeflonR;       //inner radius of the teflan covering the pcb
+  G4double fTeflonZ;
+  G4double fMylarThickness;
+  /*These parameters are used to create a flattening inside the teflon cylinder
+   where the pmt's are attached. Without the flattening placing pmt's is a pain*/
+  G4double fFlatteningWidth;
+  G4double fFlatteningHeight;  
+
+  //geometric parameters for MakeSiPMTs()
+  G4double fPMTx;
+  G4double fPMTy;
+  G4double fPMTz;
+  G4double fEpoxyz;
+  G4double fPmtR; //radius from cylinder center to pmt center
+  G4double fPMTEpoxyGap;
+  G4double fEpoxyR; //radius from cylinder center to epoxy center
+
+  G4int fNxplane; //nr of pmt's along x plane
+  G4int fNyplane; //nr of pmt's along y plane
+  G4int fNdiag1;
+  G4int fNdiag2;
+  G4int fNpmttotal;  //total nr of pmts
+
+  G4double fOffsetx; //the center pos of first pmt from the teflon end wall x plane
+  G4double fOffsety; //the center pos of first pmt from the teflon end wall y plane
+  G4double fOffsetd1;
+  G4double fOffsetd2;
+
+  G4double fStepx; //step between pmt's in x plane
+  G4double fStepy; //step between pmt's in y plane
+  G4double fStepd1;
+  G4double fStepd2;
+
+  //geometric parameters for MakeMylarSections()
+  G4double fMylarSecZ; //thickness of the sectioning windows
+  G4double fMylarWinStep; //distance between windows
+  G4double fMylarWinOffset; //the center pos of first window from the teflon end wall
+  G4int fNMylarSecWins;  //number of sectioning windows  
+
+} ;
+
+#endif
+

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -49,7 +49,7 @@ public:
   void SetOpticalProperties();
   void SetIsOverlapVol(G4int isOv){ fIsOverlapVol = isOv; }
   void ReadParameters(const char*);
-  void MakeSensitiveDetector(); //NEW
+  void MakeSensitiveDetector();
 
   //this places all sub-parts into fMyLogic
   void PlaceParts();
@@ -60,9 +60,9 @@ private:
   G4NistManager* fNistManager;
   G4int fIsOverlapVol;
 
-  G4Region* fRegionAHe3; //NEW
-  A2SD* fAHe3SD; //NEW
-  A2VisSD* fAHe3VisSD; //NEW
+  G4Region* fRegionAHe3;
+  A2SD* fAHe3SD;
+  A2VisSD* fAHe3VisSD;
 
   //------------------------------------------------------------------------
   //booleans controlling detector construction and simulation

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -13,6 +13,7 @@
 #include "G4Material.hh"
 #include "G4MaterialPropertiesTable.hh"
 #include "G4NistManager.hh"
+#include "A2SD.hh"
 
 
 class A2ActiveHe3: public A2Target
@@ -46,6 +47,7 @@ public:
   void SetOpticalProperties();
   void SetIsOverlapVol(G4bool isOv){ fIsOverlapVol = isOv; }
   void ReadParameters(const char*);
+  void MakeSensitiveDetector(); //NEW
 
   //this places all sub-parts into fMyLogic
   void PlaceParts();
@@ -55,6 +57,8 @@ private:
 
   G4NistManager* fNistManager;
   G4bool fIsOverlapVol;
+
+  A2SD* fAHe3SD; //NEW
 
   //------------------------------------------------------------------------
   //booleans controlling detector construction and simulation

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -122,10 +122,12 @@ private:
 
   // geometric parameters for MakeWLS()
   G4int fNwls;            // phi segmentation
-  G4double fWLSthick;     // plate thickness
+  G4int fNpmt;
+  G4double fWLSthick;     // WLS thickness
+  G4double fWLSwidth;     // WLS width
   G4double fRadClr;       // radial clearance to vessel
   G4double fLatClr;       // lateral clearance to vessel
-  G4double fRwls1;        // radial pos. plate centre
+  G4double fRwls1;        // radial pos. plate/fiber centre
   
   //geometric parameters for MakePCB()
   G4double fPCBThickness; //thickness of the printed circuit board

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -41,13 +41,16 @@ public:
 
   //functions that build parts of the detector
   void MakeVessel();
-  void MakeWLS();
+  void MakeWLSPlates();
+  void MakeWLSFibers();
+  void MakeWLSHelix();
   void MakePCB();
   void MakeTeflonLayer();
-  void MakeSiPMTs(){}
+  void MakeSiPMTs();
   void MakeMylarSections(G4int nrofsections);
   void DefineMaterials();
-  void SetOpticalProperties();
+  void SetOpticalPropertiesTPB();
+  void SetOpticalPropertiesHeN();
   void SetIsOverlapVol(G4int isOv){ fIsOverlapVol = isOv; }
   void ReadParameters(const char*);
   void MakeSensitiveDetector();
@@ -74,6 +77,7 @@ private:
   G4double fScintYield;
   //
   G4int fIsWLS;
+  G4int fIsTPB;
 
   //------------------------------------------------------------------------
   //volumes
@@ -85,6 +89,7 @@ private:
 
   //Logical volumes of this specific detector class
   G4LogicalVolume* fVesselLogic;        //mother for Aluminum vessel and Be windows
+  G4LogicalVolume* fHeLogic;            //mother to WLS logic
   G4LogicalVolume* fHeOutsideTeflonLogic; //mother to fPCMLogic
   G4LogicalVolume* fWLSLogic;           //WLS plate logic
   G4LogicalVolume* fPCBLogic;           //mother for Printed circuit board

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -13,7 +13,9 @@
 #include "G4Material.hh"
 #include "G4MaterialPropertiesTable.hh"
 #include "G4NistManager.hh"
+#include "G4Region.hh"
 #include "A2SD.hh"
+#include "A2VisSD.hh"
 
 
 class A2ActiveHe3: public A2Target
@@ -58,7 +60,9 @@ private:
   G4NistManager* fNistManager;
   G4bool fIsOverlapVol;
 
+  G4Region* fRegionAHe3; //NEW
   A2SD* fAHe3SD; //NEW
+  A2VisSD* fAHe3VisSD; //NEW
 
   //------------------------------------------------------------------------
   //booleans controlling detector construction and simulation

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -47,7 +47,7 @@ public:
   void MakeMylarSections(G4int nrofsections);
   void DefineMaterials();
   void SetOpticalProperties();
-  void SetIsOverlapVol(G4bool isOv){ fIsOverlapVol = isOv; }
+  void SetIsOverlapVol(G4int isOv){ fIsOverlapVol = isOv; }
   void ReadParameters(const char*);
   void MakeSensitiveDetector(); //NEW
 
@@ -58,7 +58,7 @@ public:
 private:
 
   G4NistManager* fNistManager;
-  G4bool fIsOverlapVol;
+  G4int fIsOverlapVol;
 
   G4Region* fRegionAHe3; //NEW
   A2SD* fAHe3SD; //NEW

--- a/include/A2ActiveHe3.hh
+++ b/include/A2ActiveHe3.hh
@@ -12,6 +12,7 @@
 #include "G4LogicalVolume.hh"
 #include "G4Material.hh"
 #include "G4MaterialPropertiesTable.hh"
+#include "G4OpticalSurface.hh"
 #include "G4NistManager.hh"
 #include "G4Region.hh"
 #include "A2SD.hh"
@@ -99,6 +100,8 @@ private:
 
   G4VPhysicalVolume **fPMTPhysic;   //physical volumes to set LogicalBorderSurface
   G4VPhysicalVolume **fEpoxyPhysic;
+
+  G4OpticalSurface* fSurface;
   //------------------------------------------------------------------------
   //geometric parameters
   //------------------------------------------------------------------------

--- a/include/A2CBOutput.hh
+++ b/include/A2CBOutput.hh
@@ -81,6 +81,16 @@ protected:
   Float_t *ftofy; //y hit position
   Float_t *ftofz; //z hit position
 
+  //NEW
+  //Active He3 Hits
+  Int_t fhe3n; //total number of active He3 hits
+  Int_t *fhe3i; //hit index ????
+  Float_t *fhe3e; //hit energy deposits
+  Float_t *fhe3t; //hit time
+  //Float_t *fhe3x; //x position
+  //Float_t *fhe3y; //y position
+  //Float_t *fhe3z; //z position
+  
   Int_t fnpiz; //Number of hits in Pizza detector
   Int_t fipiz[MAXSIZE_PIZZA]; //hit sector indexes
   Float_t fepiz[MAXSIZE_PIZZA]; //hit sector energy deposits

--- a/include/A2CBOutput.hh
+++ b/include/A2CBOutput.hh
@@ -17,7 +17,7 @@ const G4int MAXSIZE_TAPS= 512;
 const G4int MAXSIZE_PID= 24;
 const G4int MAXSIZE_MWPC = 400;
 const G4int MAXSIZE_PIZZA = 24;
-const G4int MAXSIZE_HE3 = 72;
+const G4int MAXSIZE_HE3 = 200;
 
 class A2CBOutput 
 {

--- a/include/A2CBOutput.hh
+++ b/include/A2CBOutput.hh
@@ -17,6 +17,7 @@ const G4int MAXSIZE_TAPS= 512;
 const G4int MAXSIZE_PID= 24;
 const G4int MAXSIZE_MWPC = 400;
 const G4int MAXSIZE_PIZZA = 24;
+const G4int MAXSIZE_HE3 = 72;
 
 class A2CBOutput 
 {
@@ -83,13 +84,13 @@ protected:
 
   //NEW
   //Active He3 Hits
-  Int_t fhe3n; //total number of active He3 hits
-  Int_t *fhe3i; //hit index ????
-  Float_t *fhe3e; //hit energy deposits
-  Float_t *fhe3t; //hit time
-  //Float_t *fhe3x; //x position
-  //Float_t *fhe3y; //y position
-  //Float_t *fhe3z; //z position
+  Int_t fnhe3; //total number of active He3 hits
+  Int_t fihe3[MAXSIZE_HE3]; //hit index
+  Float_t fehe3[MAXSIZE_HE3]; //hit energy deposits
+  Float_t fthe3[MAXSIZE_HE3]; //hit time
+  //Float_t fhe3x[MAXSIZE_HE3]; //x position
+  //Float_t fhe3y[MAXSIZE_HE3]; //y position
+  //Float_t fhe3z[MAXSIZE_HE3]; //z position
   
   Int_t fnpiz; //Number of hits in Pizza detector
   Int_t fipiz[MAXSIZE_PIZZA]; //hit sector indexes

--- a/include/A2PrimaryGeneratorAction.hh
+++ b/include/A2PrimaryGeneratorAction.hh
@@ -84,8 +84,8 @@ private:
   void OverlapGenerator(G4Event* anEvent);
   G4float fTmin;       //Min phase spce kinetic energy
   G4float fTmax;       //Max phase space kinetic energy
-  G4float fThetamin;       //Min phase spce angle
-  G4float fThetamax;       //Max phase space angle
+  G4float fThetaMin;       //Min phase spce angle
+  G4float fThetaMax;       //Max phase space angle
   G4float fBeamEnergy;    //beam energy
   G4float fBeamXSigma;    //beam X width
   G4float fBeamYSigma;    //beam X width
@@ -99,8 +99,8 @@ private:
 public:
   void SetTmin(G4float min){fTmin=min;}
   void SetTmax(G4float max){fTmax=max;}
-  void SetThetamin(G4float min){fThetamin=min;}
-  void SetThetamax(G4float max){fThetamax=max;}
+  void SetThetaMin(G4float min){fThetaMin=min;}
+  void SetThetaMax(G4float max){fThetaMax=max;}
   void SetBeamEnergy(G4float energy){fBeamEnergy=energy;}
   void SetBeamXSigma(G4float sigma){fBeamXSigma=sigma;}
   void SetBeamYSigma(G4float sigma){fBeamYSigma=sigma;}

--- a/include/A2PrimaryGeneratorAction.hh
+++ b/include/A2PrimaryGeneratorAction.hh
@@ -82,10 +82,12 @@ public:
 private:
   void PhaseSpaceGenerator(G4Event* anEvent);
   void OverlapGenerator(G4Event* anEvent);
-  G4float fTmin;       //Min phase spce kinetic energy
+  G4float fTmin;       //Min phase space kinetic energy
   G4float fTmax;       //Max phase space kinetic energy
-  G4float fThetaMin;       //Min phase spce angle
+  G4float fThetaMin;       //Min phase space angle
   G4float fThetaMax;       //Max phase space angle
+  G4float fPhiMin;       //Min phase space phi angle
+  G4float fPhiMax;       //Max phase space phi angle
   G4float fBeamEnergy;    //beam energy
   G4float fBeamXSigma;    //beam X width
   G4float fBeamYSigma;    //beam X width
@@ -101,6 +103,8 @@ public:
   void SetTmax(G4float max){fTmax=max;}
   void SetThetaMin(G4float min){fThetaMin=min;}
   void SetThetaMax(G4float max){fThetaMax=max;}
+  void SetPhiMin(G4float min){fPhiMin=min;}
+  void SetPhiMax(G4float max){fPhiMax=max;}
   void SetBeamEnergy(G4float energy){fBeamEnergy=energy;}
   void SetBeamXSigma(G4float sigma){fBeamXSigma=sigma;}
   void SetBeamYSigma(G4float sigma){fBeamYSigma=sigma;}

--- a/include/A2PrimaryGeneratorMessenger.hh
+++ b/include/A2PrimaryGeneratorMessenger.hh
@@ -38,6 +38,8 @@ class A2PrimaryGeneratorMessenger: public G4UImessenger
   G4UIcmdWithADoubleAndUnit* SetTmaxCmd;
   G4UIcmdWithADoubleAndUnit* SetThetaMinCmd;
   G4UIcmdWithADoubleAndUnit* SetThetaMaxCmd;
+  G4UIcmdWithADoubleAndUnit* SetPhiMinCmd;
+  G4UIcmdWithADoubleAndUnit* SetPhiMaxCmd;
   G4UIcmdWithADoubleAndUnit* SetBeamEnergyCmd;
   G4UIcmdWithADoubleAndUnit* SetBeamXSigmaCmd;
   G4UIcmdWithADoubleAndUnit* SetBeamYSigmaCmd;

--- a/include/A2PrimaryGeneratorMessenger.hh
+++ b/include/A2PrimaryGeneratorMessenger.hh
@@ -36,8 +36,8 @@ class A2PrimaryGeneratorMessenger: public G4UImessenger
   G4UIcmdWithAnInteger* SetSeedCmd;
   G4UIcmdWithADoubleAndUnit* SetTminCmd;
   G4UIcmdWithADoubleAndUnit* SetTmaxCmd;
-  G4UIcmdWithADoubleAndUnit* SetThetaminCmd;
-  G4UIcmdWithADoubleAndUnit* SetThetamaxCmd;
+  G4UIcmdWithADoubleAndUnit* SetThetaMinCmd;
+  G4UIcmdWithADoubleAndUnit* SetThetaMaxCmd;
   G4UIcmdWithADoubleAndUnit* SetBeamEnergyCmd;
   G4UIcmdWithADoubleAndUnit* SetBeamXSigmaCmd;
   G4UIcmdWithADoubleAndUnit* SetBeamYSigmaCmd;

--- a/include/A2Target.hh
+++ b/include/A2Target.hh
@@ -19,6 +19,7 @@ public:
 
   //virtual function to build the target needs to be implemented in derived class
   virtual G4VPhysicalVolume* Construct(G4LogicalVolume *MotherLogic, G4double Z0 = 0)=0;//Build the target
+  //virtual G4VPhysicalVolume* Construct(G4LogicalVolume *MotherLogic, G4double Z0 = 0);//Build the target
 
   G4VPhysicalVolume* GetPhysi(){return fMyPhysi;}
   G4LogicalVolume* GetLogic(){return fMyLogic;}

--- a/macros/AHeT_Setup.mac
+++ b/macros/AHeT_Setup.mac
@@ -1,0 +1,70 @@
+##Use the crystal ball?
+/A2/det/useCB 0
+#if the 3rd number in the next line is negative use old geometry,
+# if positive use new Prakhov geometry
+#the first two numbers give the upper and lower air gap between hemispheres
+#/A2/det/setHemiGap 0.4 0.4 -1 cm
+# CB crystal geometry implementation: trap=G4Trap, extr=G4ExtrudedSolid
+# G4ExtrudedSolid is default for Geant4 >= 10.4
+#/A2/det/setCBCrystGeo extr
+
+##Use TAPS?
+/A2/det/useTAPS 0
+#/A2/det/setTAPSFile data/taps07.dat
+#/A2/det/setTAPSZ 146.35 cm
+#/A2/det/setTAPSZ 188 cm
+#/A2/det/setTAPSN 384
+#/A2/det/setTAPSPbWO4Rings 2
+#/A2/det/setTAPSFile data/taps.dat
+#/A2/det/setTAPSZ 175 cm
+#/A2/det/setTAPSN 510
+
+##Use the PID
+/A2/det/usePID 0
+#/A2/det/setPIDZ 0. cm
+#/A2/det/setPIDRotation 10 deg
+
+##Use MWPC
+#set to 1 to not create the anode wires, 2 to create the anode wires
+#add 0 to disable the readout (e.g., 10, 20)
+/A2/det/useMWPC 0
+
+##Use Cherenkov?
+/A2/det/useCherenkov 0
+
+##Use TOF
+/A2/det/useTOF 0
+/A2/det/setTOFFile data/TOF.par
+
+##Use Pizza detector
+/A2/det/usePizza 0
+#/A2/det/setPizzaZ 162 cm
+
+##Set the target
+###Cryo targets : Cryo (larger cell), Cryo2 (narrower cell), CryoHe3 (He3/He4 target)
+###Materials: G4_lH2, A2_lD2, A2_lHe3, A2_lHe4
+#/A2/det/useTarget Cryo
+#/A2/det/useTarget Cryo2
+#/A2/det/useTarget CryoHe3
+/A2/det/useTarget ActiveHe3
+#/A2/det/targetMaterial G4_lH2
+/A2/det/targetMaterial A2_lHe3
+#/A2/det/setTargetLength 10 cm
+#/A2/det/setTargetZ 0. cm
+####Solid targets
+#/A2/det/useTarget Solid
+#/A2/det/useTarget Solid_Generic
+#/A2/det/useTarget Solid_Oct_18
+#/A2/det/targetMaterial G4_Pb
+#/A2/det/targetMaterial G4_GRAPHITE
+#/A2/det/targetMaterial G4_Li
+#/A2/det/targetMaterial G4_Ca
+#####Polarised target
+#/A2/det/useTarget Polarized
+#/A2/det/targetMaterial A2_HeButanol
+#/A2/det/targetMaterial A2_HeDButanol
+#/A2/det/targetMagneticCoils Solenoidal
+#/A2/det/targetMagneticCoils Saddle
+#/A2/det/setTargetMagneticFieldMap data/wouter_field_map.dat.xz
+#/A2/det/setTargetMagneticFieldMap data/field_map_jul_13_pos.dat.xz
+

--- a/macros/DetectorSetup.mac
+++ b/macros/DetectorSetup.mac
@@ -20,14 +20,14 @@
 #/A2/det/setTAPSN 510
 
 ##Use the PID
-/A2/det/usePID 2
+/A2/det/usePID 0
 /A2/det/setPIDZ 0. cm
 #/A2/det/setPIDRotation 10 deg
 
 ##Use MWPC
 #set to 1 to not create the anode wires, 2 to create the anode wires
 #add 0 to disable the readout (e.g., 10, 20)
-/A2/det/useMWPC 2
+/A2/det/useMWPC 0
 
 ##Use Cherenkov?
 /A2/det/useCherenkov 0
@@ -38,16 +38,18 @@
 
 ##Use Pizza detector
 /A2/det/usePizza 0
-/A2/det/setPizzaZ 162 cm
+#/A2/det/setPizzaZ 162 cm
 
 ##Set the target
 ###Cryo targets : Cryo (larger cell), Cryo2 (narrower cell), CryoHe3 (He3/He4 target)
 ###Materials: G4_lH2, A2_lD2, A2_lHe3, A2_lHe4
-/A2/det/useTarget Cryo
+#/A2/det/useTarget Cryo
 #/A2/det/useTarget Cryo2
 #/A2/det/useTarget CryoHe3
-/A2/det/targetMaterial G4_lH2
-/A2/det/setTargetLength 5 cm
+/A2/det/useTarget ActiveHe3
+#/A2/det/targetMaterial G4_lH2
+/A2/det/targetMaterial A2_lHe3
+#/A2/det/setTargetLength 10 cm
 #/A2/det/setTargetZ 0. cm
 ####Solid targets
 #/A2/det/useTarget Solid

--- a/macros/doActiveHe3.mac
+++ b/macros/doActiveHe3.mac
@@ -1,0 +1,38 @@
+#####Pre-Initialisation
+#Choose a physics list, for a full listing type /A2/physics/ListPhysics
+#/A2/physics/Physics QGSP_BERT
+#/A2/physics/CutsAll 1 mm
+
+####Initialise
+/run/initialize
+
+/A2/generator/Mode 1
+/A2/generator/SetTMax 10 MeV
+/A2/generator/SetTMin 10 MeV
+/A2/generator/SetThetaMin 0.0 deg
+/A2/generator/SetThetaMax 180.0 deg
+/A2/generator/SetPhiMin 0.0 deg
+/A2/generator/SetPhiMax 180.0 deg
+/A2/generator/SetBeamXSigma 3 mm
+/A2/generator/SetBeamYSigma 3 mm
+/A2/generator/SetTargetZ0 0 mm
+/A2/generator/SetTargetThick 40 cm
+/A2/generator/SetTargetRadius 5 cm
+
+#####Output
+#Open the output file for writing
+/A2/event/setOutputFile ActiveHe3_10MeV.root
+/A2/event/storePrimaries false
+
+#/gun/particle opticalphoton
+#/gun/polarization 0 1 0
+
+#/gun/particle gamma
+#/gun/particle e-
+#/gun/particle e+
+#/gun/particle pi+
+#/gun/particle proton
+#/gun/particle neutron
+/gun/particle alpha
+
+/run/beamOn 100

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -4,7 +4,7 @@
 #####Pre-Initialisation
 #Choose a physics list, for a full listing type /A2/physics/ListPhysics
 
-/A2/physics/Physics QGSP_BIC
+#/A2/physics/Physics QGSP_BIC
 
 ####Initialise
 /run/initialize
@@ -65,9 +65,9 @@
 #/vis/open DAWNFILE
 #/vis/scene/create 
 #/vis/viewer/reset
-#/vis/viewer/zoom 1.
-/vis/viewer/set/viewpointThetaPhi 130. 40.
-#/vis/viewer/set/viewpointThetaPhi 0. 0.
+/vis/viewer/zoom 3.
+#/vis/viewer/set/viewpointThetaPhi 130. 40.
+/vis/viewer/set/viewpointThetaPhi 170. 30.
 /vis/viewer/set/style surface
 #/vis/drawVolume
 #/vis/scene/endOfEventAction accumulate	
@@ -76,18 +76,15 @@
 #/vis/geometry/set/forceAuxEdgeVisible World -1 true
 /vis/viewer/set/autoRefresh true
 /vis/verbose warnings
-/vis/scene/add/axes 0 0 0 100.00 cm
-   
-/gun/particle pi-
-/gun/energy 3 MeV
-#/particle/select kaon+
-#/particle/process/inactivate 3
-#for checking CCUT
-/gun/direction 0. 0. 1
-/gun/position 0 0 0
-#/gun/position -2.924 10.2 22.98
-#/gun/position -2.924 9.7 22.98
-#/gun/position -2.558 9.7 20.66
-#/gun/position 1 9.08 0
-#/gun/position 1 15.2 0
+/vis/scene/add/axes 0 0 0 3.00 cm
 
+#/gun/particle alpha
+#/gun/energy 10 MeV
+#/gun/direction 0 -1. 0
+#/gun/position 0 0 0
+
+/gun/particle opticalphoton
+/gun/energy 3.0 eV
+/gun/position -4 0 0
+/gun/direction 0.1 0 0.7
+/gun/polarization 0 1 0

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -60,14 +60,14 @@
 # The second file will contain the detector plus one event.
 # The third file will contain the detector plus ten events.
 #/vis/open OGLI
-/vis/open OGL
+/vis/open OGL 800x600-0+0
 #/vis/open OGLIX
 #/vis/open DAWNFILE
 #/vis/scene/create 
 #/vis/viewer/reset
-/vis/viewer/zoom 3.
+/vis/viewer/zoom 2.
 #/vis/viewer/set/viewpointThetaPhi 130. 40.
-/vis/viewer/set/viewpointThetaPhi 170. 30.
+/vis/viewer/set/viewpointThetaPhi 140. 30.
 /vis/viewer/set/style surface
 #/vis/drawVolume
 #/vis/scene/endOfEventAction accumulate	
@@ -76,15 +76,15 @@
 #/vis/geometry/set/forceAuxEdgeVisible World -1 true
 /vis/viewer/set/autoRefresh true
 /vis/verbose warnings
-/vis/scene/add/axes 0 0 0 3.00 cm
+#/vis/scene/add/axes 0 0 0 5.00 cm
 
 #/gun/particle alpha
-#/gun/energy 10 MeV
-#/gun/direction 0 -1. 0
+#/gun/energy 1 MeV
+#/gun/direction 0 0 1
 #/gun/position 0 0 0
 
 /gun/particle opticalphoton
 /gun/energy 3.0 eV
-/gun/position -4 0 0
-/gun/direction 0.1 0 0.7
+/gun/position 4.0 0 0
+/gun/direction 0.25 0 0.5
 /gun/polarization 0 1 0

--- a/src/A2.cc
+++ b/src/A2.cc
@@ -4,6 +4,9 @@
 #include "G4UIterminal.hh"
 #include "G4UItcsh.hh"
 
+#define G4VIS_USE 1
+#define G4UI_USE 1
+
 #ifdef G4UI_USE_XM
 #include "G4UIXm.hh"
 #endif
@@ -13,10 +16,14 @@
 #endif
 
 #include "Randomize.hh"
+
+/*
 #ifdef G4UI_USE_QT
 #include "G4UIQt.hh"
 #include "G4Qt.hh"
 #endif
+*/
+
 #ifdef G4VIS_USE
 #include "G4VisExecutive.hh"
 #endif

--- a/src/A2.cc
+++ b/src/A2.cc
@@ -42,6 +42,7 @@
 #include "A2TrackingAction.hh"
 
 //#include "LHEP_BIC.hh"
+#include "QGSP_BERT_HP.hh"
 
 #include <getopt.h>
 
@@ -171,7 +172,7 @@ int main(int argc,char** argv) {
   // Use below insted if cannot install physics_list
   //runManager->SetUserInitialization(new A2PhysicsList);
 
-  G4VModularPhysicsList* physicsList = new A2PhysicsList;
+  G4VModularPhysicsList* physicsList = new QGSP_BERT_HP;
   G4OpticalPhysics* opticalPhysics = new G4OpticalPhysics();
 
   physicsList->RegisterPhysics(opticalPhysics);

--- a/src/A2.cc
+++ b/src/A2.cc
@@ -3,6 +3,7 @@
 #include "G4UImanager.hh"
 #include "G4UIterminal.hh"
 #include "G4UItcsh.hh"
+#include "G4OpticalPhysics.hh"
 
 #define G4VIS_USE 1
 #define G4UI_USE 1
@@ -168,7 +169,17 @@ int main(int argc,char** argv) {
   runManager->SetUserInitialization(detector);
   //runManager->SetUserInitialization(new LHEP_BIC);
   // Use below insted if cannot install physics_list
-  runManager->SetUserInitialization(new A2PhysicsList);
+  //runManager->SetUserInitialization(new A2PhysicsList);
+
+  G4VModularPhysicsList* physicsList = new A2PhysicsList;
+  G4OpticalPhysics* opticalPhysics = new G4OpticalPhysics();
+
+  physicsList->RegisterPhysics(opticalPhysics);
+  runManager->SetUserInitialization(physicsList);
+
+  // to set parameters in code, if wanted
+  //auto opticalParams = G4OpticalParameters::Instance();
+  //opticalParams->SetWLSTimeProfile("delta");
 
   G4UIsession* session = 0;
   G4UIExecutive* uiexecutive =0;

--- a/src/A2.cc
+++ b/src/A2.cc
@@ -42,6 +42,7 @@
 #include "A2TrackingAction.hh"
 
 //#include "LHEP_BIC.hh"
+#include "QGSP_BERT.hh"
 #include "QGSP_BERT_HP.hh"
 
 #include <getopt.h>
@@ -172,9 +173,10 @@ int main(int argc,char** argv) {
   // Use below insted if cannot install physics_list
   //runManager->SetUserInitialization(new A2PhysicsList);
 
-  G4VModularPhysicsList* physicsList = new QGSP_BERT_HP;
-  G4OpticalPhysics* opticalPhysics = new G4OpticalPhysics();
+  G4VModularPhysicsList* physicsList = new QGSP_BERT;
+  //G4VModularPhysicsList* physicsList = new QGSP_BERT_HP;
 
+  G4OpticalPhysics* opticalPhysics = new G4OpticalPhysics();
   physicsList->RegisterPhysics(opticalPhysics);
   runManager->SetUserInitialization(physicsList);
 

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -287,7 +287,7 @@ void A2ActiveHe3::MakeVessel() {
 
     G4VisAttributes* lblue  = new G4VisAttributes( G4Colour(0.0,0.0,0.75) );
     G4VisAttributes* grey   = new G4VisAttributes( G4Colour(0.5,0.5,0.5)  );
-    G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
+    G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0,0.5)  );
 
     fVesselLogic->SetVisAttributes(G4VisAttributes::Invisible);
     //LMainCell->SetVisAttributes(grey);

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -1028,7 +1028,7 @@ void A2ActiveHe3::PlaceParts() {
             else if(fIsWLS == 3) {
                 fNpmt = fWLSwidth/(6.1*mm);
                 xw = yw = 0;
-                zw = -z0 + 0.5*fWLSwidth + iw*(fWLSwidth + 0.5*mm);
+                zw = -z0 + ((iw + 0.5) * (fWLSwidth + 0.5*mm));
                 pp2->rotateX(90*deg);              // alignment for epoxy/SiPM
             }
 

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -53,8 +53,8 @@ A2ActiveHe3::A2ActiveHe3() {
     fEpoxyPhysic = NULL;
 
     fRegionAHe3 = new G4Region("AHe3");
-    fAHe3SD = NULL; //NEW
-    fAHe3VisSD = NULL; //NEW
+    fAHe3SD = NULL;
+    fAHe3VisSD = NULL;
 
     //initiate nist manager
     fNistManager=G4NistManager::Instance();
@@ -123,7 +123,7 @@ G4VPhysicalVolume* A2ActiveHe3::Construct(G4LogicalVolume* MotherLogical, G4doub
     PlaceParts();
 
     //construct the sensitive detector
-    MakeSensitiveDetector(); //NEW
+    MakeSensitiveDetector();
 
     //place fMyLogic into MotherLogical
     fMyPhysi = new G4PVPlacement(0, G4ThreeVector(0,0,Z0) ,fMyLogic,"ActiveHe3",fMotherLogic,false,1,fIsOverlapVol);

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -1,0 +1,1288 @@
+// He3 gas scintillator active target
+// Original coding B.Strandberg 2013-2015
+// Modified for A2Geant-Master
+// J.R.M. Annand 18th June 2020
+// J.R.M. Annand 29th June 2020 Add WLS plates option
+//
+#include "A2ActiveHe3.hh"
+
+//G4 headers
+#include "G4SDManager.hh"
+#include "G4Tubs.hh"
+#include "G4Box.hh"
+#include "G4Trd.hh"
+#include "G4NistManager.hh"    //to get elements
+#include "G4VisAttributes.hh"
+#include "G4PVPlacement.hh"
+#include "G4UnionSolid.hh"
+#include "G4SubtractionSolid.hh"
+#include "G4RotationMatrix.hh"
+#include "G4OpticalSurface.hh"
+#include "G4LogicalSkinSurface.hh"
+#include "G4LogicalBorderSurface.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4PhysicalConstants.hh"
+
+
+//constructor
+A2ActiveHe3::A2ActiveHe3() {
+
+  //initiate all pointers to NULL
+
+  //volumes
+  fMotherLogic = NULL;
+  fMyLogic = NULL;
+  fMyPhysi = NULL;
+
+  fVesselLogic = NULL;
+  fHeOutsideTeflonLogic = NULL;
+  fPCBLogic = NULL;
+  fTeflonLogic = NULL;
+  fHeInsideTeflonLogic = NULL;
+
+  fTeflonCylLogic = NULL;    
+  fTeflonCylEndLogic = NULL;
+  fPMTLogic = NULL; 
+  fEpoxyLogic = NULL;   
+  fMylarLogic = NULL;
+  fMylarSectionLogic = NULL;
+
+  fPMTPhysic = NULL;
+  fEpoxyPhysic = NULL;
+
+  //initiate nist manager
+  fNistManager=G4NistManager::Instance();
+
+  fMakeMylarSections = 0;
+  fOpticalSimulation = 0;
+  fMakeEpoxy = 1;
+  fScintYield = 65.; 
+
+  fIsOverlapVol = true;
+  fIsWLS = 1;
+  fNwls = 8;                       // phi segmentation
+  fWLSthick = 3*mm;                // thickness WLS plate
+  fRadClr = 2*mm;                  // radial clearance to vessel
+  fLatClr = 5*mm;                  // lateral clearance to vessel
+  ReadParameters("data/ActiveHe3.dat");
+}
+
+
+//destructor
+A2ActiveHe3::~A2ActiveHe3() {
+  //delete Rot;
+}
+
+/**********************************************************
+
+This function is the main constructor function that is
+called inside detector construction
+
+**********************************************************/
+G4VPhysicalVolume* A2ActiveHe3::Construct(G4LogicalVolume* MotherLogical, G4double Z0) {
+
+  G4cout << "A2ActiveHe3::Construct() Building the active target." << G4endl;
+
+  fMotherLogic = MotherLogical;
+  DefineMaterials();
+  //call functions that build parts of the detector
+  MakeVessel();                    //builds and places parts inside fVesselLogic
+  if(fIsWLS){
+    MakeWLS();                       //builds wavelength shifting plates
+  }
+  else{
+    MakePCB();                       //builds and places parts inside fPCBLogic
+    MakeTeflonLayer();               //builds and places parts inside fTeflonLayer
+    MakeSiPMTs();                    //places pmt's inside fTeflonLayer
+    //
+    if (fMakeMylarSections) {
+      G4cout << "A2ActiveHe3::Construct() Sectioning the target." << G4endl;
+      MakeMylarSections(fMakeMylarSections); //place sectioning mylar windows
+    }
+    else { G4cout << "A2ActiveHe3::Construct() Target not sectioned." << G4endl; }
+  }
+  //
+  if (fOpticalSimulation) {
+    G4cout << "A2ActiveHe3::Construct() Setting optical properties." << G4endl;
+    SetOpticalProperties(); //set optical properties and surfaces
+  }
+  else { G4cout << "A2ActiveHe3::Construct() Optical properties not used." << G4endl; }
+
+  //place the separate parts into main logic of this detector 
+  PlaceParts();
+
+  //place fMyLogic into MotherLogical
+  fMyPhysi = new G4PVPlacement(0, G4ThreeVector(0,0,0) ,fMyLogic,"ActiveHe3",fMotherLogic,false,1,fIsOverlapVol);
+
+  return fMyPhysi;
+}
+
+
+/**********************************************************
+
+This function builds the aluminum vessel and the Be windows
+and places them to member fVesselLogic
+
+**********************************************************/
+void A2ActiveHe3::MakeVessel() {
+  //------------------------------------------------------------------------------
+  //Define shapes (solids)
+  //------------------------------------------------------------------------------
+
+  G4Tubs *VesselCyl = new G4Tubs
+    ("VesselCyl",
+     0,                              //inner radius
+     fHeContainerR+fContainerThickness,   //outer radius=biggest part
+     fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness,
+     0.*deg,                         //start angle
+     360.*deg);                      //final angle
+
+
+  //main container cylinder
+  G4Tubs *MainCell = new G4Tubs("MainCell",
+				fHeContainerR,                     //inner radius
+				fHeContainerR+fContainerThickness, //outer radius
+				fHeContainerZ/2,                     //length
+				0.*deg,                            //start angle
+				360.*deg);                         //final angle
+
+  //upstream extension tube cylinder
+  G4Tubs *ExtCellU = new G4Tubs("ExtensionU",
+				fExtensionR,                     //inner radius
+				fExtensionR+fContainerThickness, //outer radius
+				fExtensionZU/2,                     //length
+				0.*deg,                          //start angle
+				360.*deg);                       //final angle
+
+  //downstream extension tube cylinder
+  G4Tubs *ExtCellD = new G4Tubs("ExtensionD",
+				fExtensionR,                     //inner radius
+				fExtensionR+fContainerThickness, //outer radius
+				fExtensionZD/2,                     //length
+				0.*deg,                          //start angle
+				360.*deg);                       //final angle
+
+  //main cell end wall with a hole in the middle where extension
+  //cylinder connects to main cell
+  G4Tubs *MainCellEnd = new G4Tubs("MainCellEnd",
+				fExtensionR,                       //inner radius
+				fHeContainerR+fContainerThickness, //outer radius
+				fContainerThickness/2,               //length
+				0.*deg,                            //start angle
+				360.*deg);                         //final angle
+  //be windows
+  G4Tubs *BerylliumWindow = new G4Tubs("BerylliumWindow",
+				       0,                     //inner radius
+				       fExtensionR,              //outer radius
+				       fBeThickness/2,             //length
+				       0.*deg,                   //start angle
+				       360.*deg);                //final angle
+
+  //gas that fills the main cell outside teflon
+  G4Tubs *HeMainCell = new G4Tubs("HeMainCell",
+				0,                              //inner radius
+				fHeContainerR,                  //outer radius
+				fHeContainerZ/2,                //length
+				0.*deg,                         //start angle
+				360.*deg);                      //final angle
+
+  //he inside extension tubes
+  G4Tubs *HeExtCellU = new G4Tubs("HeExtCellU",
+				  0,                        //inner radius
+				  fExtensionR,              //outer radius
+				  (fExtensionZU+fContainerThickness)/2,     //length
+				  0.*deg,                   //start angle
+				  360.*deg);            //final angle
+  G4Tubs *HeExtCellD = new G4Tubs("HeExtCellD",
+				  0,                        //inner radius
+				  fExtensionR,              //outer radius
+				  (fExtensionZD+fContainerThickness)/2,     //length
+				  0.*deg,                   //start angle
+				  360.*deg);            //final angle
+
+  //create union solid for the He gas to create 1 logical volume
+  //that can be set to sensitive detector
+  G4UnionSolid* HeUnion1 = new G4UnionSolid
+    ("HeUnion1",
+     HeMainCell,
+     HeExtCellU,
+     0,  //no rotation
+     G4ThreeVector(0, 0, -(fHeContainerZ+fExtensionZU+fContainerThickness)/2) ); //move extension cell
+  
+  G4UnionSolid* HeOutsideTeflon = new G4UnionSolid
+    ("HeOutsideTeflon",
+     HeUnion1,
+     HeExtCellD,
+     0,  //no rotation
+     G4ThreeVector(0, 0, +(fHeContainerZ+fExtensionZD+fContainerThickness)/2) ); //move extension cell
+  
+
+  //------------------------------------------------------------------------------
+  //Define logical volumes
+  //------------------------------------------------------------------------------
+
+  //invoke fVesselLogic
+  fVesselLogic = new G4LogicalVolume
+    (VesselCyl,   //solid
+     fNistManager->FindOrBuildMaterial("G4_AIR"), //material
+     "LfVesselLogic");
+
+
+  G4LogicalVolume *LMainCell = new G4LogicalVolume
+    (MainCell,   //solid
+     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+     "LogicMainCell");
+
+  G4LogicalVolume *LExtCellU = new G4LogicalVolume
+    (ExtCellU,   //solid
+     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+     "LogicExtCellU");
+
+  G4LogicalVolume *LExtCellD = new G4LogicalVolume
+    (ExtCellD,   //solid
+     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+     "LogicExtCellD");
+  
+  G4LogicalVolume *LMainCellEnd = new G4LogicalVolume
+    (MainCellEnd,   //solid
+     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+     "LogicMainCellEnd");
+  
+  G4LogicalVolume *LBerylliumWindow = new G4LogicalVolume
+    (BerylliumWindow,   //solid
+     fNistManager->FindOrBuildMaterial("G4_Be"), //material
+     "LogicBerylliumWindow");
+
+  fHeOutsideTeflonLogic = new G4LogicalVolume
+    (HeOutsideTeflon,
+     fNistManager->FindOrBuildMaterial("ATGasMix"),
+     "LogicHeOutsideTeflon"
+     );
+
+  //------------------------------------------------------------------------------
+  //Set visual attributes
+  //------------------------------------------------------------------------------
+
+  G4VisAttributes* lblue  = new G4VisAttributes( G4Colour(0.0,0.0,0.75) );
+  G4VisAttributes* grey   = new G4VisAttributes( G4Colour(0.5,0.5,0.5)  );
+  G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
+
+  fVesselLogic->SetVisAttributes(G4VisAttributes::Invisible);
+  LMainCell->SetVisAttributes(grey);
+  LExtCellU->SetVisAttributes(grey);
+  LExtCellD->SetVisAttributes(grey);
+  LMainCellEnd->SetVisAttributes(grey);
+  LBerylliumWindow->SetVisAttributes(lblue);
+  fHeOutsideTeflonLogic->SetVisAttributes(cyan);
+
+  //------------------------------------------------------------------------------
+  //Create placements of the logical volumes
+  //------------------------------------------------------------------------------
+  
+  //place main vessel
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0,0,0), //main vessel in the centre
+		     LMainCell,            //main cell logic
+		     "PMainCell",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     11,fIsOverlapVol);                  //copy number 
+
+
+  //place main cell ends
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , ( fHeContainerZ/2 + fContainerThickness/2 ) ),
+		     LMainCellEnd,            //main cell end piece
+		     "PMainCellEnd1",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     12,fIsOverlapVol);                  //copy number 
+
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness/2 ) ),
+		     LMainCellEnd,            //main cell end piece
+		     "PMainCellEnd2",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     13,fIsOverlapVol);                  //copy number 
+
+
+  //place extension cells
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness + fExtensionZU/2 ) ),
+		     LExtCellU,            //extension cell logic
+		     "PExtCellU",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     14,fIsOverlapVol);                  //copy number 
+
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , +( fHeContainerZ/2 + fContainerThickness + fExtensionZD/2 ) ),
+		     LExtCellD,            //extension cell logic
+		     "PExtCellD",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     15,fIsOverlapVol);                  //copy number 
+
+
+  //place Be windows 
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness/2 ) ),
+		     LBerylliumWindow,            //beryllium window logic
+		     "PBeWindowU",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     16,fIsOverlapVol);                  //copy number 
+
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , +( fHeContainerZ/2 + fContainerThickness + fExtensionZD + fBeThickness/2 ) ),
+		     LBerylliumWindow,            //beryllium window logic
+		     "PBeWindowD",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     17,fIsOverlapVol);                  //copy number 
+
+} //end of MakeVessel()
+
+//-----------------------------------------------------------------------------------
+// WLS plates to fit inside vessel
+// Use plastic scintillator material as its the same PVT base
+// Each plate is trapesoid.
+// fNwls phi segmentation...default 8-fold
+// Looking down beam axis they form a fNwls-sided polygon. A small gap is maintained
+// between each plate so that light will not readily pass from one plate to the next.
+// WLS plates are positioned in PlaceParts()
+// JRMA 29/06/2020
+//-----------------------------------------------------------------------------------
+void A2ActiveHe3::MakeWLS()
+{
+  G4double th = 360.0*deg/fNwls;
+  G4double r0 = fHeContainerR - fRadClr;
+  fRwls1 = r0*cos(th/2) - 0.5*fWLSthick;
+  G4double z0 = fHeContainerZ/2 - fLatClr;
+  G4double d0 = r0*sin(th/2) - 0.001*mm; // slightly smaller so plates dont touch
+  G4double d1 = d0 - fWLSthick*tan(th/2);
+  G4Trd* wls = new G4Trd("WLS-bar", z0,z0,d0,d1,fWLSthick/2);
+  fWLSLogic = new G4LogicalVolume
+    (wls,fNistManager->FindOrBuildMaterial("G4_PLASTIC_SC_VINYLTOLUENE"),
+     "LogicWLS");
+  G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
+  fWLSLogic->SetVisAttributes(blue);
+}
+
+
+/**********************************************************
+
+This function builds the printed circuit board and places
+it to member fPCBLogic
+
+**********************************************************/
+void A2ActiveHe3::MakePCB() {
+
+  //------------------------------------------------------------------------------
+  //Define parameter values
+  //------------------------------------------------------------------------------
+
+  fPCBThickness = 1.*mm;
+  fPCBRadius = fHeContainerR-4.5*mm; //define as a function of container R
+  fTeflonThicknessEnd = 1.*mm;
+  fPCBZ = fHeContainerZ - 20.*mm + 2*fTeflonThicknessEnd;
+  //------------------------------------------------------------------------------
+  //Define shapes (solids)
+  //------------------------------------------------------------------------------
+
+  //pcb is one cylinder
+  G4Tubs *PCB = new G4Tubs("PCB",
+  //			   fPCBRadius,                     //inner radius
+			   0,                     //inner radius
+			   fPCBRadius+fPCBThickness,       //outer radius
+			   fPCBZ/2,                  //length
+			   0.*deg,                         //start angle
+			   360.*deg);                      //final angle
+
+  //------------------------------------------------------------------------------
+  //Define logical volumes
+  //------------------------------------------------------------------------------
+
+  //invoke fPCBLogic
+  fPCBLogic = new G4LogicalVolume
+    (PCB,   //solid
+     fNistManager->FindOrBuildMaterial("G4_C"), //material
+     "LfPCBLogic");
+
+  //------------------------------------------------------------------------------
+  //Set visual attributes
+  //------------------------------------------------------------------------------
+
+  G4VisAttributes* lgreen = new G4VisAttributes( G4Colour(0.0,0.75,0.0) );
+
+  fPCBLogic->SetVisAttributes(lgreen);
+
+  //fPCBLogic is placed inside fVesselLogic in function PlaceParts()
+} //end of MakePCB()
+
+
+/**********************************************************
+
+This function builds the teflan layer and Al-mylar windows
+and places them to member fTeflanLogic
+
+**********************************************************/
+void A2ActiveHe3::MakeTeflonLayer() {
+
+  //------------------------------------------------------------------------------
+  //Define parameter values
+  //------------------------------------------------------------------------------
+  //fTeflonThicknessEnd = 1.*mm; //defined in MakePCB() to calculate pcb length
+  fTeflonThicknessCyl = 0.5*mm;
+  fTeflonR = fPCBRadius - fTeflonThicknessCyl; //reduced from original 95 to 70 mm, see doc
+  fTeflonZ = fPCBZ - 2*fTeflonThicknessEnd; //such length that teflonz+2endcaps=pcbz
+  fMylarThickness = 0.005*mm;
+
+  /*parameters for the flat parts on teflon cyl where the pmt's go
+    the minimum flattening height depending on R was calculated as
+    h(fTeflonR) = fTeflonR - sqrt(fTeflonR^2 - (fPMTx/2)^2). The used 
+    number is more just in case. For h(R=95) = 0.047mm; h(R=46) = 0.098mm*/
+  fFlatteningWidth = 6*mm;
+  fFlatteningHeight = 0.12*mm;
+ 
+  //------------------------------------------------------------------------------
+  //Define shapes (solids)
+  //------------------------------------------------------------------------------
+
+  G4Tubs *TeflonLogicCyl = new G4Tubs
+    ("TeflonLogicCyl",
+     0,                              //inner radius
+     fTeflonR+fTeflonThicknessCyl,   //outer radius
+     fPCBZ/2,                        //same length as pcb
+     0.*deg,                         //start angle
+     360.*deg);                      //final angle
+  
+
+  //teflan cylinder covering pcb
+  G4Tubs *TeflonCyl = new G4Tubs("TeflonCyl",
+				 fTeflonR,                       //inner radius
+				 fTeflonR+fTeflonThicknessCyl,   //outer radius
+				 fTeflonZ/2,                     //length
+				 0.*deg,                         //start angle
+				 360.*deg);                      //final angle
+
+  G4Tubs *TeflonCylEnd = new G4Tubs("TeflonCylEnd",
+				    fExtensionR,                  //inner radius
+				    fTeflonR+fTeflonThicknessCyl, //outer radius
+				    fTeflonThicknessEnd/2,          //length
+				    0.*deg,                       //start angle
+				    360.*deg);                    //final angle
+
+  G4Tubs *MylarWindow = new G4Tubs("MylarWindow",
+				    0,                       //inner radius
+				    fExtensionR,             //outer radius
+				    fMylarThickness/2,          //length
+				    0.*deg,                  //start angle
+				    360.*deg);               //final angle
+
+  G4Box *Flattening = new G4Box("Flattening", fFlatteningWidth/2, fFlatteningHeight/2, fTeflonZ/2);
+
+  //create rotations
+  G4double theta = 90*deg;
+  G4ThreeVector u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+  G4ThreeVector v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+  G4ThreeVector w = G4ThreeVector(0, 0, 1);
+  G4RotationMatrix *rotz90  = new G4RotationMatrix(u, v, w);
+
+  theta = 45*deg;
+  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+  w = G4ThreeVector(0, 0, 1);
+  G4RotationMatrix *rotz45  = new G4RotationMatrix(u, v, w);
+
+  theta = 135*deg;
+  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+  w = G4ThreeVector(0, 0, 1);
+  G4RotationMatrix *rotz135  = new G4RotationMatrix(u, v, w);
+
+  G4UnionSolid* TefU1 = new G4UnionSolid
+    ("TefU1",
+     TeflonCyl,
+     Flattening,
+     rotz90,  
+     G4ThreeVector(fTeflonR-fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+  G4UnionSolid* TefU2 = new G4UnionSolid
+    ("TefU2",
+     TefU1,
+     Flattening,
+     rotz90, 
+     G4ThreeVector(-fTeflonR+fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+  G4UnionSolid* TefU3 = new G4UnionSolid
+    ("TefU3",
+     TefU2,
+     Flattening,
+     0, 
+     G4ThreeVector(0, fTeflonR-fFlatteningHeight/2, 0) ); //move the flattening part
+
+  G4UnionSolid* TefU4 = new G4UnionSolid
+    ("TefU4",
+     TefU3,
+     Flattening,
+     0, 
+     G4ThreeVector(0, -fTeflonR+fFlatteningHeight/2, 0) ); //move the flattening part
+
+
+  G4UnionSolid* TefU5 = new G4UnionSolid
+    ("TefU5",
+     TefU4,
+     Flattening,
+     rotz45,  
+     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+  G4UnionSolid* TefU6 = new G4UnionSolid
+    ("TefU6",
+     TefU5,
+     Flattening,
+     rotz45, 
+     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+  G4UnionSolid* TefU7 = new G4UnionSolid
+    ("TefU7",
+     TefU6,
+     Flattening,
+     rotz135,  
+     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+  G4UnionSolid* TefU8 = new G4UnionSolid
+    ("TefU8",
+     TefU7,
+     Flattening,
+     rotz135, 
+     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+    
+  //he inside the teflon cylinder 
+  G4Tubs *HeTube = new G4Tubs("HeTube",
+				 0,                       //inner radius
+				 fTeflonR+fTeflonThicknessCyl,   //outer radius
+				 fTeflonZ/2,               // same length as teflon main cyl
+				 0.*deg,                         //start angle
+				 360.*deg);                      //final angle
+
+  //he gas = teflon main cyl (outer r) - teflon main cyl solid
+  G4SubtractionSolid* HeInsideTeflon = new G4SubtractionSolid
+    ("HeInsideTeflon",
+     HeTube,
+     TefU8 );
+
+  //------------------------------------------------------------------------------
+  //Define logical volumes
+  //------------------------------------------------------------------------------
+
+  //invoke fTeflonLogic
+  fTeflonLogic = new G4LogicalVolume
+    (TeflonLogicCyl,   //solid
+     //fNistManager->FindOrBuildMaterial("G4_AIR"), //material
+     fNistManager->FindOrBuildMaterial("ATGasMix"),
+     "LfTeflonLogic");
+
+  fTeflonCylLogic = new G4LogicalVolume
+    (TefU8,   //solid
+     fNistManager->FindOrBuildMaterial("ATTeflon"), //material
+     "LTeflonCyl");
+  
+  fTeflonCylEndLogic = new G4LogicalVolume
+    (TeflonCylEnd,   //solid
+     fNistManager->FindOrBuildMaterial("ATTeflon"), //material
+     "LTeflonCylEnd");
+
+  fMylarLogic = new G4LogicalVolume
+    (MylarWindow,   //solid
+     fNistManager->FindOrBuildMaterial("ATMylarW"), //material
+     "LMylarWindow");
+
+  fHeInsideTeflonLogic = new G4LogicalVolume
+    (HeInsideTeflon,   //solid
+     fNistManager->FindOrBuildMaterial("ATGasMix"), //material
+     "LHeInsideTeflon");
+
+  //------------------------------------------------------------------------------
+  //Set visual attributes
+  //------------------------------------------------------------------------------
+
+  G4VisAttributes* red    = new G4VisAttributes( G4Colour(0.3,0.0,0.0)  );
+  G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
+  G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
+
+  fTeflonLogic->SetVisAttributes(G4VisAttributes::Invisible);
+  fTeflonCylLogic ->SetVisAttributes(red);
+  fTeflonCylEndLogic->SetVisAttributes(red);
+  fMylarLogic->SetVisAttributes(blue);
+  fHeInsideTeflonLogic->SetVisAttributes(cyan);
+
+  //------------------------------------------------------------------------------
+  //Create placements of the logical volumes
+  //------------------------------------------------------------------------------
+  
+  //place the teflon cylinder
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0,0,0), //teflon cylinder in the centre
+		     fTeflonCylLogic,                 //teflon cylinder logic
+		     "PTeflonCyl",               //name
+		     fTeflonLogic,            //mother logic (teflonLogic)
+		     false,                //pMany = false, true is not implemented
+		     31,fIsOverlapVol);                  //copy number 
+
+  //place cylinder end walls
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , ( fTeflonZ/2 + fTeflonThicknessEnd/2 ) ),
+		     fTeflonCylEndLogic,            //main cell end piece
+		     "PTeflonCylEnd1",          //name
+		     fTeflonLogic,         //mother logic (teflonLogic)
+		     false,                //pMany = false, true is not implemented
+		     32,fIsOverlapVol);                  //copy number 
+
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , -( fTeflonZ/2 + fTeflonThicknessEnd/2 ) ),
+		     fTeflonCylEndLogic,            //main cell end piece
+		     "PTeflonCylEnd2",          //name
+		     fTeflonLogic,         //mother logic (teflonLogic)
+		     false,                //pMany = false, true is not implemented
+		     33,fIsOverlapVol);                  //copy number 
+
+  //place the mylar windows
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , ( fTeflonZ/2 + fMylarThickness/2 ) ),
+		     fMylarLogic,            //mylar window
+		     "PMylarWindow1",          //name
+		     fTeflonLogic,         //mother logic (teflonLogic)
+		     false,                //pMany = false, true is not implemented
+		     34,fIsOverlapVol);                  //copy number 
+
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0 , -( fTeflonZ/2 + fMylarThickness/2 ) ),
+		     fMylarLogic,            //mylar window
+		     "PMylarWindow2",          //name
+		     fTeflonLogic,         //mother logic (teflonLogic)
+		     false,                //pMany = false, true is not implemented
+		     35,fIsOverlapVol);                  //copy number 
+
+} //end of MakeTeflonLayer()
+
+
+
+
+/**********************************************************
+
+This function builds mylar windows to section the main cell
+The flattening for pmt's made it a bit tricky. Simply copied
+over the logic that was used to create the teflon cylider,
+flattening and helium inside it and scaled down the z dimension
+to mylar thickness
+
+**********************************************************/
+void A2ActiveHe3::MakeMylarSections(G4int nrofsections) {
+
+  //---------------------------------------------------------------------------
+  //Define parameters
+  //---------------------------------------------------------------------------
+  fMylarSecZ = 0.005*mm;
+
+  if (nrofsections == 8) {
+    G4cout << "A2ActiveHe3::MakeMylarSections() Sectioning active target to 8." << G4endl;
+    fMylarWinStep = 50.*mm;          //values with 8 sections
+    fMylarWinOffset = 50.*mm;
+    fNMylarSecWins = 7;
+  }
+  else if (nrofsections == 4) {
+    G4cout << "A2ActiveHe3::MakeMylarSections() Sectioning active target to 4." << G4endl;
+    fMylarWinStep = 100.*mm;         //values with 4 sections
+    fMylarWinOffset = 100.*mm;
+    fNMylarSecWins = 3;
+  }
+  else {
+    G4cout << "A2ActiveHe3::MakeMylarSections() Unsupported number of active target sections defined, the target will not be sectioned." << G4endl;
+    return;
+  }
+
+  //------------------------------------------------------------------------------
+  //Create solid
+  //------------------------------------------------------------------------------
+  G4Tubs *MylarSecOuter = new G4Tubs("MylarSecOuter",
+				     fTeflonR,                       //inner radius
+				     fTeflonR+fTeflonThicknessCyl,   //outer radius
+				     fMylarSecZ/2,                     //length
+				     0.*deg,                         //start angle
+				     360.*deg);                      //final angle
+  
+  G4Box *MylarSecFlattening = new G4Box("MylarSecFlattening", fFlatteningWidth/2, fFlatteningHeight/2, fMylarSecZ/2);
+  
+  //create rotations
+  G4double theta = 90*deg;
+  G4ThreeVector u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+  G4ThreeVector v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+  G4ThreeVector w = G4ThreeVector(0, 0, 1);
+  G4RotationMatrix *rotz90  = new G4RotationMatrix(u, v, w);
+
+  theta = 45*deg;
+  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+  w = G4ThreeVector(0, 0, 1);
+  G4RotationMatrix *rotz45  = new G4RotationMatrix(u, v, w);
+
+  theta = 135*deg;
+  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+  w = G4ThreeVector(0, 0, 1);
+  G4RotationMatrix *rotz135  = new G4RotationMatrix(u, v, w);
+
+  G4UnionSolid* MylU1 = new G4UnionSolid
+    ("MylU1",
+     MylarSecOuter,
+     MylarSecFlattening,
+     rotz90,  
+     G4ThreeVector(fTeflonR-fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+  G4UnionSolid* MylU2 = new G4UnionSolid
+    ("MylU2",
+     MylU1,
+     MylarSecFlattening,
+     rotz90, 
+     G4ThreeVector(-fTeflonR+fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+  G4UnionSolid* MylU3 = new G4UnionSolid
+    ("MylU3",
+     MylU2,
+     MylarSecFlattening,
+     0, 
+     G4ThreeVector(0, fTeflonR-fFlatteningHeight/2, 0) ); //move the flattening part
+
+  G4UnionSolid* MylU4 = new G4UnionSolid
+    ("MylU4",
+     MylU3,
+     MylarSecFlattening,
+     0, 
+     G4ThreeVector(0, -fTeflonR+fFlatteningHeight/2, 0) ); //move the flattening part
+
+
+  G4UnionSolid* MylU5 = new G4UnionSolid
+    ("MylU5",
+     MylU4,
+     MylarSecFlattening,
+     rotz45,  
+     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+  G4UnionSolid* MylU6 = new G4UnionSolid
+    ("MylU6",
+     MylU5,
+     MylarSecFlattening,
+     rotz45, 
+     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+  G4UnionSolid* MylU7 = new G4UnionSolid
+    ("MylU7",
+     MylU6,
+     MylarSecFlattening,
+     rotz135,  
+     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+  G4UnionSolid* MylU8 = new G4UnionSolid
+    ("MylU8",
+     MylU7,
+     MylarSecFlattening,
+     rotz135, 
+     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+    
+  //mylar inside the teflon cylinder 
+  G4Tubs *MylarSec = new G4Tubs("MylarSec",
+				 0,                       //inner radius
+				 fTeflonR+fTeflonThicknessCyl,   //outer radius
+				 fMylarSecZ/2,               
+				 0.*deg,                         //start angle
+				 360.*deg);                      //final angle
+
+  //create the actual solid
+  G4SubtractionSolid* MylarInsideTeflon = new G4SubtractionSolid
+    ("MylarInsideTeflon",
+     MylarSec,
+     MylU8 );
+
+  //------------------------------------------------------------------------------
+  //Create logical volume
+  //------------------------------------------------------------------------------
+  fMylarSectionLogic = new G4LogicalVolume
+    (MylarInsideTeflon,
+     fNistManager->FindOrBuildMaterial("ATMylarW"),
+     "LMylarSection");
+
+  //------------------------------------------------------------------------------
+  //Create placements of the logical volumes
+  //------------------------------------------------------------------------------
+  G4int nwindows;
+  for (nwindows = 0; nwindows < fNMylarSecWins; nwindows++) {
+
+    //place the mylar sectioning windows along z
+    new G4PVPlacement 
+      (0,
+       G4ThreeVector(0, 0, -fTeflonZ/2 + fMylarWinOffset + nwindows*fMylarWinStep),
+       fMylarSectionLogic,
+       "PMylarSection",                  //name
+       fHeInsideTeflonLogic,            //mother logic 
+       false,                   //pMany = false, true is not implemented
+       200+nwindows,fIsOverlapVol);                  //copy number 
+      
+  } //end of for loop for mylar windows placement
+
+} //end MakeMylarSections()
+
+
+
+
+/**********************************************************
+
+This function places the separate logical parts of the
+detector inside fMyLogic
+
+**********************************************************/
+void A2ActiveHe3::PlaceParts() {
+
+  //------------------------------------------------------------------------------
+  //Define shape for fMyLogic and construct it (simple cylinder that
+  //has room for everything)
+  //------------------------------------------------------------------------------
+
+  G4Tubs *MyLogicCyl = new G4Tubs
+    ("MyLogicCyl",
+     0,                              //inner radius
+     fHeContainerR+fContainerThickness,   //outer radius
+     fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness,
+     0.*deg,                         //start angle
+     360.*deg);                      //final angle
+
+  fMyLogic = new G4LogicalVolume
+    (MyLogicCyl,                                  //solid
+     fNistManager->FindOrBuildMaterial("G4_AIR"), //material
+     "LfMyLogic");                                //name
+
+  fMyLogic->SetVisAttributes(G4VisAttributes::Invisible);  
+
+  //------------------------------------------------------------------------------
+  //Place parts of the detector
+  //------------------------------------------------------------------------------
+  if(!fIsWLS){
+    //place the helium inside teflon cylinder
+    new G4PVPlacement (0,  //no rotation
+		       G4ThreeVector(0,0,0), //teflon cylinder in the centre
+		       fHeInsideTeflonLogic,     //helium logic
+		       "PHeInsideTeflon",        //name
+		       fTeflonLogic,            //mother logic (teflonLogic)
+		       false,                //pMany = false, true is not implemented
+		       45,fIsOverlapVol);                  //copy number 
+    
+    //place the teflon layer insice pcb
+    new G4PVPlacement (0,                    //no rotation
+		       G4ThreeVector(0,0,0), //center
+		       fTeflonLogic,         //main cell logic
+		       "PTeflonLogic",       //name
+		       fPCBLogic,             //mother logic
+		       false,                //pMany = false, true is not implemented
+		       44,fIsOverlapVol);                  //copy number
+
+    //place the pcb inside the outside helium
+    new G4PVPlacement (0,                    //no rotation
+		       G4ThreeVector(0,0,0), //center
+		       fPCBLogic,            //main cell logic
+		       "PPCBLogic",          //name
+		       fHeOutsideTeflonLogic,//mother logic
+		       false,                //pMany = false, true is not implemented
+		       43,fIsOverlapVol);    //copy number
+  }
+  //place the outside helium inside vessel
+  new G4PVPlacement (0,  //no rotation
+		     G4ThreeVector(0, 0, 0),
+		     fHeOutsideTeflonLogic,            //he gas logic
+		     "PHeOutsideTeflon",          //name
+		     fVesselLogic,         //mother logic (vessel)
+		     false,                //pMany = false, true is not implemented
+		     42,fIsOverlapVol);                  //copy number
+  //
+  // place WLS plates in He gas volume
+  // loop round phi segments (sides of polygon)
+  // NB copy numbers provisionally set 140 onwards...this may have to change
+  // 
+  G4double th = 360*deg/fNwls;
+  G4double th2 = 0.0;
+  for(G4int iw=0; iw<fNwls; iw++){
+    G4RotationMatrix* pp = new G4RotationMatrix();
+    G4double th1 = iw*th;
+    pp->rotateY(90*deg);            // align parallel beam axis
+    pp->rotateX(th1);               // align for side of polygon
+    G4double xw = fRwls1*cos(th2);  // coordinates for polygon side
+    G4double yw = fRwls1*sin(th2);
+    char nw[16];
+    sprintf(nw,"PWLS_%d",iw);
+    new G4PVPlacement (pp,
+		       G4ThreeVector(xw, yw, 0),
+		       fWLSLogic,         
+		       nw,     
+		       fHeOutsideTeflonLogic,//mother logic (He)
+		       false,                //pMany = false
+		       140+iw,fIsOverlapVol);    //copy number
+    th2 -= th;
+  }
+
+  //place the vessel inside MyLogic
+  new G4PVPlacement (0,                    //no rotation
+  		     G4ThreeVector(0,0,0), //center
+  		     fVesselLogic,         //main cell logic
+  		     "PVesselLogic",       //name
+  		     fMyLogic,             //mother logic
+  		     false,                //pMany = false, true is not implemented
+  		     41,fIsOverlapVol);    //copy number
+
+}
+
+
+/**********************************************************
+
+This function sets the optical properties
+for some materials and surfaces
+
+**********************************************************/
+void A2ActiveHe3::SetOpticalProperties() {
+
+  //------------------------------------------------------------------------------
+  //gas mixture
+  //------------------------------------------------------------------------------
+  const G4int nentries = 18;
+
+  //Photon energies 1.88 - 3.87 eV --> 660 - 320 nm, even step of 20 nm
+  G4double HeN_Energy[nentries] = {1.88*eV, 1.94*eV, 2.0*eV, 2.07*eV, 2.14*eV, 2.21*eV, 2.3*eV,
+				   2.38*eV, 2.48*eV, 2.58*eV, 2.7*eV, 2.82*eV, 2.95*eV, 3.1*eV,
+				   3.26*eV, 3.44*eV, 3.65*eV, 3.87*eV};
+
+  //this gives a peak from 400 to 440 nm --> 3.1 to 2.95 eV
+  G4double HeN_SCINT[nentries] = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+				  0.1, 0.1, 0.1, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1};
+
+  //See ref in Seian's paper; no need for higher accuracy in my opinion
+  G4double HeN_RIND[nentries] =
+    {1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003,
+     1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003}; 
+
+  //absorption length  
+  G4double HeN_ABSL[nentries] = 
+    {3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm, 3500.*cm,
+     3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm, 3500.*cm};
+  
+  G4MaterialPropertiesTable* HeN_mt = new G4MaterialPropertiesTable();
+  HeN_mt->AddProperty("FASTCOMPONENT", HeN_Energy, HeN_SCINT, nentries);
+  HeN_mt->AddProperty("SLOWCOMPONENT", HeN_Energy, HeN_SCINT, nentries);
+  HeN_mt->AddProperty("RINDEX",        HeN_Energy, HeN_RIND,  nentries);
+  HeN_mt->AddProperty("ABSLENGTH",     HeN_Energy, HeN_ABSL,  nentries);
+
+  HeN_mt->AddConstProperty("SCINTILLATIONYIELD", fScintYield/MeV   );    
+  HeN_mt->AddConstProperty("RESOLUTIONSCALE" ,   1.0        );  
+
+  //numbers from Jonh's optical simulation--------------
+  // HeN_mt->AddConstProperty("FASTTIMECONSTANT",20.*ns);
+  // HeN_mt->AddConstProperty("SLOWTIMECONSTANT",45.*ns);
+  // HeN_mt->AddConstProperty("YIELDRATIO",1.0);
+
+  //numbers from Active target simulation with gdml file
+  // HeN_mt->AddConstProperty("FASTTIMECONSTANT",   0.5*ns     );// 8  ns  20
+  // HeN_mt->AddConstProperty("SLOWTIMECONSTANT",   23.*ns     );// 23 ns  45
+  // HeN_mt->AddConstProperty("YIELDRATIO",         0.5        );
+
+  //numbers according to Seian's thesis-----------------
+  HeN_mt->AddConstProperty("FASTTIMECONSTANT",   30.*ns     );
+  HeN_mt->AddConstProperty("SLOWTIMECONSTANT",   60.*ns     );
+  HeN_mt->AddConstProperty("YIELDRATIO",         1.0        );
+  //----------------------------------------------------
+
+  //add these properties to GasMix
+  fNistManager->FindOrBuildMaterial("ATGasMix")->SetMaterialPropertiesTable(HeN_mt);
+
+  //------------------------------------------------------------------------------
+  //teflon properties
+  //------------------------------------------------------------------------------
+
+  //PTFE reflectivity from Janecek
+  //"REFLECTIVITY SPECTRA FOR COMMONLY USED REFLECTORS"
+  G4double PTFE_Reflectivity[nentries] =
+    {0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95,
+     0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95};
+
+  G4MaterialPropertiesTable* Teflon_mt = new G4MaterialPropertiesTable();
+  Teflon_mt->AddProperty("REFLECTIVITY",HeN_Energy, PTFE_Reflectivity ,nentries);
+
+  fNistManager->FindOrBuildMaterial("ATTeflon")->SetMaterialPropertiesTable(Teflon_mt);
+  
+  //------------------------------------------------------------------------------
+  //mylar
+  //------------------------------------------------------------------------------
+
+  //flat 95% according to Seian's thesis
+  G4double mylar_REFL[nentries] = 
+    {0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95,
+     0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95};
+
+  //These seem to be the same as for quartz. In terms of the simulation
+  //these numbers are not very relevant. Interpolated and extrapolated
+  //results of Seian to match my energies and range
+  // G4double mylar_RIND[nentries] =
+  //   {1.51551, 1.5173, 1.51899, 1.52084, 1.52256, 1.52418, 1.52611,
+  //    1.52752, 1.52931, 1.53097, 1.53321, 1.53548, 1.53828, 1.54184,
+  //    1.54528, 1.55176, 1.55819, 1.56375};
+
+  //http://www.filmetrics.com/refractive-index-database/PET/Estar-Melinex-Mylar
+  G4double mylar_RIND[nentries] =
+    {1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 
+     1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68};
+
+  G4MaterialPropertiesTable* Mylar_mt = new G4MaterialPropertiesTable();
+  Mylar_mt->AddProperty("REFLECTIVITY",HeN_Energy, mylar_REFL ,nentries); 
+  Mylar_mt->AddProperty("RINDEX",HeN_Energy,mylar_RIND, nentries);
+
+  fNistManager->FindOrBuildMaterial("ATMylarW")->SetMaterialPropertiesTable(Mylar_mt);
+
+  //------------------------------------------------------------------------------
+  //Epoxy (best guesses I could do)
+  //------------------------------------------------------------------------------
+
+  //the film refractive index at 589 nm from Martin Sharratt's e-mail
+  //no dependency known
+  G4double Epoxy_RIND[nentries] =
+    {1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54,
+     1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54};
+
+  //use 1, the pmt acceptance spectrum already includes the epoxy effect according
+  //to e-mail from Sharratt
+  G4double Epoxy_Transmittance[nentries] = 
+    {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+     1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+  
+  G4MaterialPropertiesTable *Epoxy_mt = new G4MaterialPropertiesTable();
+  Epoxy_mt->AddProperty("RINDEX",HeN_Energy,Epoxy_RIND, nentries);
+  Epoxy_mt->AddProperty("TRANSMITTANCE", HeN_Energy, Epoxy_Transmittance, nentries);
+
+  fNistManager->FindOrBuildMaterial("ATEpoxy")->SetMaterialPropertiesTable(Epoxy_mt);
+
+  //------------------------------------------------------------------------------
+  //Silicon photomultipliers (currently set so that every hit is detected!)
+  //------------------------------------------------------------------------------
+
+  // detect every photon that hits the pmt. This can be used to correlate which
+  // wavelengths are detected more efficiently
+  G4double SiPMT_EFF[nentries] = 
+    {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+     1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  // Photocathod reflectivity, currently 0, so detect all
+  G4double SiPMT_REFL[nentries]   =  
+    {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+  G4MaterialPropertiesTable *SiPMT_mt = new G4MaterialPropertiesTable();
+  SiPMT_mt->AddProperty("EFFICIENCY",HeN_Energy,SiPMT_EFF, nentries);
+  SiPMT_mt->AddProperty("REFLECTIVITY",HeN_Energy,SiPMT_REFL, nentries);
+  
+  fNistManager->FindOrBuildMaterial("ATSiPMT")->SetMaterialPropertiesTable(SiPMT_mt);
+
+  //------------------------------------------------------------------------------
+  //Create optical surfaces
+  //------------------------------------------------------------------------------
+  
+  //teflon - only lambertian reflection, relatively OK simple approximation
+  G4OpticalSurface* OptTeflonSurface = 
+    new G4OpticalSurface("OTeflonSurface",  unified, groundfrontpainted, dielectric_dielectric);
+
+  //relate the materials table
+  OptTeflonSurface->SetMaterialPropertiesTable(Teflon_mt);
+
+  //set optical surfaces
+  new G4LogicalSkinSurface("LSTeflonCylSurface",fTeflonCylLogic, OptTeflonSurface);
+  new G4LogicalSkinSurface("LSTeflonEndSurface",fTeflonCylEndLogic, OptTeflonSurface);
+
+  //------------------------------------------------------------------------------------
+
+  //Mylar windows. model uses only reflection and absorption
+  G4OpticalSurface* OptMylarSurface = 
+    new G4OpticalSurface("OMylarSurface",  unified, polishedfrontpainted, dielectric_dielectric);
+  OptMylarSurface->SetMaterialPropertiesTable(Mylar_mt);
+
+  new G4LogicalSkinSurface("LSMylarSurface", fMylarLogic, OptMylarSurface);
+  if (fMakeMylarSections) {
+    new G4LogicalSkinSurface("LSMylarSecSurface", fMylarSectionLogic, OptMylarSurface);
+  }
+
+ //------------------------------------------------------------------------------------
+
+  //epoxy surface.  It should reflect, refract or absorb
+  if (fMakeEpoxy) {
+    G4OpticalSurface* OptEpoxySurface = 
+      new G4OpticalSurface("OEpoxySurface",  unified, ground, dielectric_dielectric);
+    //janecek, moses 2010; ground sigmaalpha 12 deg = 0.21rad 
+    OptEpoxySurface->SetSigmaAlpha(0.21);
+    OptEpoxySurface->SetMaterialPropertiesTable(Epoxy_mt);
+    
+    new G4LogicalSkinSurface("LSEpoxySurface", fEpoxyLogic, OptEpoxySurface);
+  }
+
+ //------------------------------------------------------------------------------------
+
+  //pmt surface. The specified model uses ONLY reflection or absorption
+  G4OpticalSurface* OptPmtSurface = 
+    new G4OpticalSurface("OPmtSurface",  unified, polishedfrontpainted, dielectric_dielectric);
+  OptPmtSurface->SetMaterialPropertiesTable(SiPMT_mt);
+
+  new G4LogicalSkinSurface("LSPmtSurfarce", fPMTLogic, OptPmtSurface);
+
+} //end SetOpticalProperties()
+
+void A2ActiveHe3::SetScintillationYield(G4double scintyield) {
+
+  if (scintyield > 0.01) {
+    fScintYield = scintyield;
+    G4cout << "A2ActiveHe3::SetScintillationYield() Using user-set scintillation yield value " << 
+      fScintYield << " per MeV" << G4endl;
+  }
+  else {
+    G4cout << "A2ActiveHe3::SetScintillationYield() Using default value for fScintYield " << 
+      fScintYield << " per MeV" << G4endl;
+  }
+}
+void A2ActiveHe3::DefineMaterials()
+{
+  G4double density, fractionmass;
+  G4int ncomponents;
+  G4double pressure, temperature, a, z;
+
+  G4Material* BerylliumW = new G4Material("ATBerylliumW", density = 1.8480*g/cm3, ncomponents = 7);
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(14), 0.06*perCent);      //Si
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(4), 98.73*perCent);      //Be
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(6), 0.15*perCent);       //C
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(8), 0.75*perCent);       //O
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(12), 0.08*perCent);      //Mg
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(13), 0.1*perCent);       //Al
+  BerylliumW->AddElement(fNistManager->FindOrBuildElement(26), 0.13*perCent);      //Fe
+
+  G4Material* MylarW = new G4Material("ATMylarW", density = 1.4000*g/cm3, ncomponents = 3);
+  MylarW->AddElement(fNistManager->FindOrBuildElement(1), 4.2*perCent);           //H
+  MylarW->AddElement(fNistManager->FindOrBuildElement(6), 62.5*perCent);          //C
+  MylarW->AddElement(fNistManager->FindOrBuildElement(8), 33.3*perCent);          //O
+
+  G4Material* Teflon = new G4Material("ATTeflon", density = 2.2000*g/cm3, ncomponents = 2);
+  Teflon->AddElement(fNistManager->FindOrBuildElement(6), 24*perCent);            //C
+  Teflon->AddElement(fNistManager->FindOrBuildElement(9), 76*perCent);            //F
+
+
+  //Gas mixture and He3 management----------------------------------------------------
+
+  //defining He3 according to
+  // http://hypernews.slac.stanford.edu/HyperNews/geant4/get/hadronprocess/731/1.html
+  G4Element* ATHe3 = new G4Element("ATHe3", "ATHe3", ncomponents=1);
+  ATHe3->AddIsotope((G4Isotope*)fNistManager->FindOrBuildElement(2)->GetIsotope(0), //isot. 0 = 3he
+		    100.*perCent);
+
+  //See HeGasDensity.nb. Might be an idea to include N2 effect to density
+  //G4double he3density = 0.00247621*g/cm3; //20bar, calculated from ideal gas law
+  G4double he3density = 0.0033*g/cm3; //20bar, calculated from ideal gas law
+
+  G4Material* GasMix = new G4Material("ATGasMix", he3density, ncomponents = 2);
+  GasMix->AddElement(ATHe3, 99.95*perCent);                                       //He3
+  // GasMix->AddElement(fNistManager->FindOrBuildElement(2), 99.95*perCent);         //He4
+  GasMix->AddElement(fNistManager->FindOrBuildElement(7), 0.05*perCent);           //N
+  //Gas mixture and He3 end-----------------------------------------------------
+  //----! IMPORTANT! Epoxy CURRENTLY TAKEN FROM A2 SIMULATION,------------------
+  //NO IDEA WHETHER IT IS CORRECT OR NOT
+
+  //Epoxy resin (C21H25Cl05) ***not certain if correct chemical formula or density
+  //for colder temperature***:
+  G4Material* EpoxyResin=new G4Material("EpoxyResin", density=1.15*g/cm3, ncomponents=4);
+  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(6), 21); //carbon
+  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(1), 25); //hydrogen
+  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(17), 1); //chlorine
+  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(8), 5);  //oxygen
+
+  //Amine Hardener (C8H18N2) ***not certain if correct chemical formula or density 
+  //for colder temperature***:
+  G4Material* Epoxy13BAC=new G4Material("Epoxy13BAC", density=0.94*g/cm3, ncomponents=3);
+  Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(6), 8);
+  Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(1), 18);
+  Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(7), 2);
+
+  //Epoxy adhesive with mix ratio 100:25 parts by weight resin/hardener
+  // ***don't know density at cold temperature***:
+  G4Material* Epoxy=new G4Material("ATEpoxy", density=1.2*g/cm3, ncomponents=2);
+  Epoxy->AddMaterial(EpoxyResin, fractionmass=0.8);
+  Epoxy->AddMaterial(Epoxy13BAC, fractionmass=0.2);
+  //-----------------------------------------------------------------------------
+
+  //just silicon for now
+  G4Material* SiPMT = new G4Material("ATSiPMT", density = 2.329*g/cm3, ncomponents = 1);
+  SiPMT->AddElement(fNistManager->FindOrBuildElement(14),100.*perCent);    //Si
+
+}
+
+//---------------------------------------------------------------------------
+void A2ActiveHe3::ReadParameters(const char* file)
+{
+  //
+  // Initialise detector parameters from file
+  //
+  char* keylist[] = { (char *)"AT-Dim:", (char *)"AT-WLS:", 
+		      (char *)"AT-Scint:", (char *)"Run-Mode:", NULL };
+  enum { EAT_Dim, EAT_WLS, EAT_Scint, ERun_Mode, ENULL };
+  G4int ikey, iread;
+  G4int ierr = 0;
+  char line[256];
+  char delim[64];
+  char hname[32];
+  char fname[32];
+  G4double x,y,z,dx,dy,dz;
+  FILE* pdata;
+  if( (pdata = fopen(file,"r")) == NULL ){
+    printf("Error opening detector parameter file: %s\n",file);
+    return;
+  }
+  while( fgets(line,256,pdata) ){
+    if( line[0] == '#' ) continue;       // comment #
+    printf("%s\n",line);                 // record datum to log
+    sscanf(line,"%s",delim);
+    for(ikey=0; ikey<ENULL; ikey++)
+      if(!strcmp(keylist[ikey],delim)) break;
+    switch( ikey ){
+    default:
+      printf("Unrecognised delimiter: %s\n",delim);
+      ierr++;
+      break;
+    case EAT_Dim:
+      iread = sscanf(line,"%*s%lf%lf%lf%lf%lf%lf%lf",
+		     &fHeContainerZ,&fHeContainerR,&fContainerThickness,
+		     &fExtensionZU,&fExtensionZD,&fExtensionR,&fBeThickness);
+      if( iread != 7 ) ierr++;
+      break;
+    case EAT_WLS:
+      iread = sscanf(line,"%*s%d%lf%lf%lf",
+		     &fNwls,&fWLSthick,&fRadClr,&fLatClr);
+      if( iread != 4 ) ierr++;
+      break;
+    case EAT_Scint:
+      iread =sscanf(line,"%*s%lf",
+		    &fScintYield);
+      if( iread != 1 ) ierr++;
+      break;
+    case ERun_Mode:
+      iread = sscanf(line,"%*s%d%d%d%d",
+		     &fIsOverlapVol,&fIsWLS,&fOpticalSimulation,&fMakeMylarSections);
+      if( iread != 4 ) ierr++;
+      break;
+    }
+    if( ierr ){
+      printf("Fatal Error: invalid read of parameter line %s\n %s\n",
+	     keylist[ikey],line);
+      exit(-1);
+    }
+  }
+}

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -435,7 +435,7 @@ void A2ActiveHe3::MakeWLSHelix()
 {
     G4double r0 = fHeContainerR - fRadClr;
     fRwls1 = r0 - 0.5*fWLSthick;
-    G4double z0 = ((fHeContainerZ/2 - fLatClr)/fNwls) - 0.05*cm; // slightly smaller so rings dont touch;
+    G4double z0 = ((fHeContainerZ/2 - fLatClr)/fNwls) - 0.25*mm; // slightly smaller so rings dont touch;
     fWLSwidth = 2*z0;
 
     //G4Tubs* wls = new G4Tubs("WLS-ring", r0 - fWLSthick, r0, z0, 5*deg, 355*deg);
@@ -1028,7 +1028,7 @@ void A2ActiveHe3::PlaceParts() {
             else if(fIsWLS == 3) {
                 fNpmt = fWLSwidth/(6.1*mm);
                 xw = yw = 0;
-                zw = -z0 + 0.5*fWLSwidth + iw*(fWLSwidth + 0.1*cm);
+                zw = -z0 + 0.5*fWLSwidth + iw*(fWLSwidth + 0.5*mm);
                 pp2->rotateX(90*deg);              // alignment for epoxy/SiPM
             }
 

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -29,57 +29,57 @@
 //constructor
 A2ActiveHe3::A2ActiveHe3() {
 
-  //initiate all pointers to NULL
+    //initiate all pointers to NULL
 
-  //volumes
-  fMotherLogic = NULL;
-  fMyLogic = NULL;
-  fMyPhysi = NULL;
+    //volumes
+    fMotherLogic = NULL;
+    fMyLogic = NULL;
+    fMyPhysi = NULL;
 
-  fVesselLogic = NULL;
-  fHeOutsideTeflonLogic = NULL;
-  fPCBLogic = NULL;
-  fTeflonLogic = NULL;
-  fHeInsideTeflonLogic = NULL;
+    fVesselLogic = NULL;
+    fHeOutsideTeflonLogic = NULL;
+    fPCBLogic = NULL;
+    fTeflonLogic = NULL;
+    fHeInsideTeflonLogic = NULL;
 
-  fTeflonCylLogic = NULL;    
-  fTeflonCylEndLogic = NULL;
-  fPMTLogic = NULL; 
-  fEpoxyLogic = NULL;   
-  fMylarLogic = NULL;
-  fMylarSectionLogic = NULL;
+    fTeflonCylLogic = NULL;
+    fTeflonCylEndLogic = NULL;
+    fPMTLogic = NULL;
+    fEpoxyLogic = NULL;
+    fMylarLogic = NULL;
+    fMylarSectionLogic = NULL;
 
-  fPMTPhysic = NULL;
-  fEpoxyPhysic = NULL;
+    fPMTPhysic = NULL;
+    fEpoxyPhysic = NULL;
 
-  fRegionAHe3 = new G4Region("AHe3");
-  fAHe3SD = NULL; //NEW
-  fAHe3VisSD = NULL; //NEW
+    fRegionAHe3 = new G4Region("AHe3");
+    fAHe3SD = NULL; //NEW
+    fAHe3VisSD = NULL; //NEW
 
-  //initiate nist manager
-  fNistManager=G4NistManager::Instance();
+    //initiate nist manager
+    fNistManager=G4NistManager::Instance();
 
-  fMakeMylarSections = 0;
-  fOpticalSimulation = 0;
-  fMakeEpoxy = 1;
-  fScintYield = 65.; 
+    fMakeMylarSections = 0;
+    fOpticalSimulation = 0;
+    fMakeEpoxy = 1;
+    fScintYield = 65.;
 
-  fIsOverlapVol = true;
-  fIsWLS = 1;
-  fNwls = 8;                       // phi segmentation
-  fWLSthick = 3*mm;                // thickness WLS plate
-  fRadClr = 2*mm;                  // radial clearance to vessel
-  fLatClr = 5*mm;                  // lateral clearance to vessel
-  ReadParameters("data/ActiveHe3.dat");
+    fIsOverlapVol = true;
+    fIsWLS = 1;
+    fNwls = 8;                       // phi segmentation
+    fWLSthick = 3*mm;                // thickness WLS plate
+    fRadClr = 2*mm;                  // radial clearance to vessel
+    fLatClr = 5*mm;                  // lateral clearance to vessel
+    ReadParameters("data/ActiveHe3.dat");
 }
 
 
 //destructor
 A2ActiveHe3::~A2ActiveHe3() {
-  //delete Rot;
-  if(fRegionAHe3) delete fRegionAHe3; //remove the sensitive detector
-  if(fAHe3SD) delete fAHe3SD; //remove the sensitive detector
-  if(fAHe3VisSD) delete fAHe3VisSD; //remove the sensitive detector
+    //delete Rot;
+    if(fRegionAHe3) delete fRegionAHe3; //remove the sensitive detector
+    if(fAHe3SD) delete fAHe3SD; //remove the sensitive detector
+    if(fAHe3VisSD) delete fAHe3VisSD; //remove the sensitive detector
 }
 
 /**********************************************************
@@ -90,45 +90,45 @@ called inside detector construction
 **********************************************************/
 G4VPhysicalVolume* A2ActiveHe3::Construct(G4LogicalVolume* MotherLogical, G4double Z0) {
 
-  G4cout << "A2ActiveHe3::Construct() Building the active target." << G4endl;
+    G4cout << "A2ActiveHe3::Construct() Building the active target." << G4endl;
 
-  fMotherLogic = MotherLogical;
-  DefineMaterials();
-  //call functions that build parts of the detector
-  MakeVessel();                    //builds and places parts inside fVesselLogic
-  
-  if(fIsWLS){
-    MakeWLS();                       //builds wavelength shifting plates
-  }
-  else{
-    MakePCB();                       //builds and places parts inside fPCBLogic
-    MakeTeflonLayer();               //builds and places parts inside fTeflonLayer
-    MakeSiPMTs();                    //places pmt's inside fTeflonLayer
-    //
-    if (fMakeMylarSections) {
-      G4cout << "A2ActiveHe3::Construct() Sectioning the target." << G4endl;
-      MakeMylarSections(fMakeMylarSections); //place sectioning mylar windows
+    fMotherLogic = MotherLogical;
+    DefineMaterials();
+    //call functions that build parts of the detector
+    MakeVessel();                    //builds and places parts inside fVesselLogic
+
+    if(fIsWLS){
+        MakeWLS();                       //builds wavelength shifting plates
     }
-    else { G4cout << "A2ActiveHe3::Construct() Target not sectioned." << G4endl; }
-  }
-  //
-  if (fOpticalSimulation) {
-    G4cout << "A2ActiveHe3::Construct() Setting optical properties." << G4endl;
-    SetOpticalProperties(); //set optical properties and surfaces
-  }
-  else { G4cout << "A2ActiveHe3::Construct() Optical properties not used." << G4endl; }
-  //
+    else{
+        MakePCB();                       //builds and places parts inside fPCBLogic
+        MakeTeflonLayer();               //builds and places parts inside fTeflonLayer
+        MakeSiPMTs();                    //places pmt's inside fTeflonLayer
+        //
+        if (fMakeMylarSections) {
+            G4cout << "A2ActiveHe3::Construct() Sectioning the target." << G4endl;
+            MakeMylarSections(fMakeMylarSections); //place sectioning mylar windows
+        }
+        else { G4cout << "A2ActiveHe3::Construct() Target not sectioned." << G4endl; }
+    }
+    //
+    if (fOpticalSimulation) {
+        G4cout << "A2ActiveHe3::Construct() Setting optical properties." << G4endl;
+        SetOpticalProperties(); //set optical properties and surfaces
+    }
+    else { G4cout << "A2ActiveHe3::Construct() Optical properties not used." << G4endl; }
+    //
 
-  //place the separate parts into main logic of this detector 
-  PlaceParts();
+    //place the separate parts into main logic of this detector
+    PlaceParts();
 
-  //construct the sensitive detector
-  MakeSensitiveDetector(); //NEW
-  
-  //place fMyLogic into MotherLogical
-  fMyPhysi = new G4PVPlacement(0, G4ThreeVector(0,0,0) ,fMyLogic,"ActiveHe3",fMotherLogic,false,1,fIsOverlapVol);
+    //construct the sensitive detector
+    MakeSensitiveDetector(); //NEW
 
-  return fMyPhysi;
+    //place fMyLogic into MotherLogical
+    fMyPhysi = new G4PVPlacement(0, G4ThreeVector(0,0,Z0) ,fMyLogic,"ActiveHe3",fMotherLogic,false,1,fIsOverlapVol);
+
+    return fMyPhysi;
 }
 
 
@@ -139,228 +139,228 @@ and places them to member fVesselLogic
 
 **********************************************************/
 void A2ActiveHe3::MakeVessel() {
-  //------------------------------------------------------------------------------
-  //Define shapes (solids)
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Define shapes (solids)
+    //------------------------------------------------------------------------------
 
-  G4Tubs *VesselCyl = new G4Tubs
-    ("VesselCyl",
-     0,                              //inner radius
-     fHeContainerR+fContainerThickness,   //outer radius=biggest part
-     fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness,
-     0.*deg,                         //start angle
-     360.*deg);                      //final angle
-
-
-  //main container cylinder
-  G4Tubs *MainCell = new G4Tubs("MainCell",
-				fHeContainerR,                     //inner radius
-				fHeContainerR+fContainerThickness, //outer radius
-				fHeContainerZ/2,                     //length
-				0.*deg,                            //start angle
-				360.*deg);                         //final angle
-
-  //upstream extension tube cylinder
-  G4Tubs *ExtCellU = new G4Tubs("ExtensionU",
-				fExtensionR,                     //inner radius
-				fExtensionR+fContainerThickness, //outer radius
-				fExtensionZU/2,                     //length
-				0.*deg,                          //start angle
-				360.*deg);                       //final angle
-
-  //downstream extension tube cylinder
-  G4Tubs *ExtCellD = new G4Tubs("ExtensionD",
-				fExtensionR,                     //inner radius
-				fExtensionR+fContainerThickness, //outer radius
-				fExtensionZD/2,                     //length
-				0.*deg,                          //start angle
-				360.*deg);                       //final angle
-
-  //main cell end wall with a hole in the middle where extension
-  //cylinder connects to main cell
-  G4Tubs *MainCellEnd = new G4Tubs("MainCellEnd",
-				fExtensionR,                       //inner radius
-				fHeContainerR+fContainerThickness, //outer radius
-				fContainerThickness/2,               //length
-				0.*deg,                            //start angle
-				360.*deg);                         //final angle
-  //be windows
-  G4Tubs *BerylliumWindow = new G4Tubs("BerylliumWindow",
-				       0,                     //inner radius
-				       fExtensionR,              //outer radius
-				       fBeThickness/2,             //length
-				       0.*deg,                   //start angle
-				       360.*deg);                //final angle
-
-  //gas that fills the main cell outside teflon
-  G4Tubs *HeMainCell = new G4Tubs("HeMainCell",
-				0,                              //inner radius
-				fHeContainerR,                  //outer radius
-				fHeContainerZ/2,                //length
-				0.*deg,                         //start angle
-				360.*deg);                      //final angle
-
-  //he inside extension tubes
-  G4Tubs *HeExtCellU = new G4Tubs("HeExtCellU",
-				  0,                        //inner radius
-				  fExtensionR,              //outer radius
-				  (fExtensionZU+fContainerThickness)/2,     //length
-				  0.*deg,                   //start angle
-				  360.*deg);            //final angle
-  G4Tubs *HeExtCellD = new G4Tubs("HeExtCellD",
-				  0,                        //inner radius
-				  fExtensionR,              //outer radius
-				  (fExtensionZD+fContainerThickness)/2,     //length
-				  0.*deg,                   //start angle
-				  360.*deg);            //final angle
-
-  //create union solid for the He gas to create 1 logical volume
-  //that can be set to sensitive detector
-  G4UnionSolid* HeUnion1 = new G4UnionSolid
-    ("HeUnion1",
-     HeMainCell,
-     HeExtCellU,
-     0,  //no rotation
-     G4ThreeVector(0, 0, -(fHeContainerZ+fExtensionZU+fContainerThickness)/2) ); //move extension cell
-  
-  G4UnionSolid* HeOutsideTeflon = new G4UnionSolid
-    ("HeOutsideTeflon",
-     HeUnion1,
-     HeExtCellD,
-     0,  //no rotation
-     G4ThreeVector(0, 0, +(fHeContainerZ+fExtensionZD+fContainerThickness)/2) ); //move extension cell
-  
-
-  //------------------------------------------------------------------------------
-  //Define logical volumes
-  //------------------------------------------------------------------------------
-
-  //invoke fVesselLogic
-  fVesselLogic = new G4LogicalVolume
-    (VesselCyl,   //solid
-     fNistManager->FindOrBuildMaterial("G4_AIR"), //material
-     "LfVesselLogic");
+    G4Tubs *VesselCyl = new G4Tubs
+            ("VesselCyl",
+             0,                              //inner radius
+             fHeContainerR+fContainerThickness,   //outer radius=biggest part
+             fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness,
+             0.*deg,                         //start angle
+             360.*deg);                      //final angle
 
 
-  G4LogicalVolume *LMainCell = new G4LogicalVolume
-    (MainCell,   //solid
-     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
-     "LogicMainCell");
+    //main container cylinder
+    G4Tubs *MainCell = new G4Tubs("MainCell",
+                                  fHeContainerR,                     //inner radius
+                                  fHeContainerR+fContainerThickness, //outer radius
+                                  fHeContainerZ/2,                     //length
+                                  0.*deg,                            //start angle
+                                  360.*deg);                         //final angle
 
-  G4LogicalVolume *LExtCellU = new G4LogicalVolume
-    (ExtCellU,   //solid
-     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
-     "LogicExtCellU");
+    //upstream extension tube cylinder
+    G4Tubs *ExtCellU = new G4Tubs("ExtensionU",
+                                  fExtensionR,                     //inner radius
+                                  fExtensionR+fContainerThickness, //outer radius
+                                  fExtensionZU/2,                     //length
+                                  0.*deg,                          //start angle
+                                  360.*deg);                       //final angle
 
-  G4LogicalVolume *LExtCellD = new G4LogicalVolume
-    (ExtCellD,   //solid
-     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
-     "LogicExtCellD");
-  
-  G4LogicalVolume *LMainCellEnd = new G4LogicalVolume
-    (MainCellEnd,   //solid
-     fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
-     "LogicMainCellEnd");
-  
-  G4LogicalVolume *LBerylliumWindow = new G4LogicalVolume
-    (BerylliumWindow,   //solid
-     fNistManager->FindOrBuildMaterial("G4_Be"), //material
-     "LogicBerylliumWindow");
+    //downstream extension tube cylinder
+    G4Tubs *ExtCellD = new G4Tubs("ExtensionD",
+                                  fExtensionR,                     //inner radius
+                                  fExtensionR+fContainerThickness, //outer radius
+                                  fExtensionZD/2,                     //length
+                                  0.*deg,                          //start angle
+                                  360.*deg);                       //final angle
 
-  fHeOutsideTeflonLogic = new G4LogicalVolume
-    (HeOutsideTeflon,
-     fNistManager->FindOrBuildMaterial("ATGasMix"),
-     "LogicHeOutsideTeflon"
-     );
+    //main cell end wall with a hole in the middle where extension
+    //cylinder connects to main cell
+    G4Tubs *MainCellEnd = new G4Tubs("MainCellEnd",
+                                     fExtensionR,                       //inner radius
+                                     fHeContainerR+fContainerThickness, //outer radius
+                                     fContainerThickness/2,               //length
+                                     0.*deg,                            //start angle
+                                     360.*deg);                         //final angle
+    //be windows
+    G4Tubs *BerylliumWindow = new G4Tubs("BerylliumWindow",
+                                         0,                     //inner radius
+                                         fExtensionR,              //outer radius
+                                         fBeThickness/2,             //length
+                                         0.*deg,                   //start angle
+                                         360.*deg);                //final angle
 
-  //------------------------------------------------------------------------------
-  //Set visual attributes
-  //------------------------------------------------------------------------------
+    //gas that fills the main cell outside teflon
+    G4Tubs *HeMainCell = new G4Tubs("HeMainCell",
+                                    0,                              //inner radius
+                                    fHeContainerR,                  //outer radius
+                                    fHeContainerZ/2,                //length
+                                    0.*deg,                         //start angle
+                                    360.*deg);                      //final angle
 
-  G4VisAttributes* lblue  = new G4VisAttributes( G4Colour(0.0,0.0,0.75) );
-  G4VisAttributes* grey   = new G4VisAttributes( G4Colour(0.5,0.5,0.5)  );
-  G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
+    //he inside extension tubes
+    G4Tubs *HeExtCellU = new G4Tubs("HeExtCellU",
+                                    0,                        //inner radius
+                                    fExtensionR,              //outer radius
+                                    (fExtensionZU+fContainerThickness)/2,     //length
+                                    0.*deg,                   //start angle
+                                    360.*deg);            //final angle
+    G4Tubs *HeExtCellD = new G4Tubs("HeExtCellD",
+                                    0,                        //inner radius
+                                    fExtensionR,              //outer radius
+                                    (fExtensionZD+fContainerThickness)/2,     //length
+                                    0.*deg,                   //start angle
+                                    360.*deg);            //final angle
 
-  fVesselLogic->SetVisAttributes(G4VisAttributes::Invisible);
-  LMainCell->SetVisAttributes(grey);
-  //LMainCell->SetVisAttributes(G4VisAttributes::Invisible);
-  LExtCellU->SetVisAttributes(grey);
-  //LExtCellU->SetVisAttributes(G4VisAttributes::Invisible);
-  LExtCellD->SetVisAttributes(grey);
-  //LExtCellD->SetVisAttributes(G4VisAttributes::Invisible);
-  LMainCellEnd->SetVisAttributes(grey);
-  //LMainCellEnd->SetVisAttributes(G4VisAttributes::Invisible);
-  LBerylliumWindow->SetVisAttributes(lblue);
-  //LBerylliumWindow->SetVisAttributes(G4VisAttributes::Invisible);
-  fHeOutsideTeflonLogic->SetVisAttributes(cyan);
-  //fHeOutsideTeflonLogic->SetVisAttributes(G4VisAttributes::Invisible);
+    //create union solid for the He gas to create 1 logical volume
+    //that can be set to sensitive detector
+    G4UnionSolid* HeUnion1 = new G4UnionSolid
+            ("HeUnion1",
+             HeMainCell,
+             HeExtCellU,
+             0,  //no rotation
+             G4ThreeVector(0, 0, -(fHeContainerZ+fExtensionZU+fContainerThickness)/2) ); //move extension cell
 
-  //------------------------------------------------------------------------------
-  //Create placements of the logical volumes
-  //------------------------------------------------------------------------------
-  
-  //place main vessel
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0,0,0), //main vessel in the centre
-		     LMainCell,            //main cell logic
-		     "PMainCell",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     11,fIsOverlapVol);                  //copy number 
-
-
-  //place main cell ends
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , ( fHeContainerZ/2 + fContainerThickness/2 ) ),
-		     LMainCellEnd,            //main cell end piece
-		     "PMainCellEnd1",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     12,fIsOverlapVol);                  //copy number 
-
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness/2 ) ),
-		     LMainCellEnd,            //main cell end piece
-		     "PMainCellEnd2",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     13,fIsOverlapVol);                  //copy number 
+    G4UnionSolid* HeOutsideTeflon = new G4UnionSolid
+            ("HeOutsideTeflon",
+             HeUnion1,
+             HeExtCellD,
+             0,  //no rotation
+             G4ThreeVector(0, 0, +(fHeContainerZ+fExtensionZD+fContainerThickness)/2) ); //move extension cell
 
 
-  //place extension cells
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness + fExtensionZU/2 ) ),
-		     LExtCellU,            //extension cell logic
-		     "PExtCellU",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     14,fIsOverlapVol);                  //copy number 
+    //------------------------------------------------------------------------------
+    //Define logical volumes
+    //------------------------------------------------------------------------------
 
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , +( fHeContainerZ/2 + fContainerThickness + fExtensionZD/2 ) ),
-		     LExtCellD,            //extension cell logic
-		     "PExtCellD",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     15,fIsOverlapVol);                  //copy number 
+    //invoke fVesselLogic
+    fVesselLogic = new G4LogicalVolume
+            (VesselCyl,   //solid
+             fNistManager->FindOrBuildMaterial("G4_AIR"), //material
+             "LfVesselLogic");
 
 
-  //place Be windows 
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness/2 ) ),
-		     LBerylliumWindow,            //beryllium window logic
-		     "PBeWindowU",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     16,fIsOverlapVol);                  //copy number 
+    G4LogicalVolume *LMainCell = new G4LogicalVolume
+            (MainCell,   //solid
+             fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+             "LogicMainCell");
 
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , +( fHeContainerZ/2 + fContainerThickness + fExtensionZD + fBeThickness/2 ) ),
-		     LBerylliumWindow,            //beryllium window logic
-		     "PBeWindowD",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     17,fIsOverlapVol);                  //copy number 
+    G4LogicalVolume *LExtCellU = new G4LogicalVolume
+            (ExtCellU,   //solid
+             fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+             "LogicExtCellU");
+
+    G4LogicalVolume *LExtCellD = new G4LogicalVolume
+            (ExtCellD,   //solid
+             fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+             "LogicExtCellD");
+
+    G4LogicalVolume *LMainCellEnd = new G4LogicalVolume
+            (MainCellEnd,   //solid
+             fNistManager->FindOrBuildMaterial("G4_STAINLESS-STEEL"), //material
+             "LogicMainCellEnd");
+
+    G4LogicalVolume *LBerylliumWindow = new G4LogicalVolume
+            (BerylliumWindow,   //solid
+             fNistManager->FindOrBuildMaterial("G4_Be"), //material
+             "LogicBerylliumWindow");
+
+    fHeOutsideTeflonLogic = new G4LogicalVolume
+            (HeOutsideTeflon,
+             fNistManager->FindOrBuildMaterial("ATGasMix"),
+             "LogicHeOutsideTeflon"
+             );
+
+    //------------------------------------------------------------------------------
+    //Set visual attributes
+    //------------------------------------------------------------------------------
+
+    G4VisAttributes* lblue  = new G4VisAttributes( G4Colour(0.0,0.0,0.75) );
+    G4VisAttributes* grey   = new G4VisAttributes( G4Colour(0.5,0.5,0.5)  );
+    G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
+
+    fVesselLogic->SetVisAttributes(G4VisAttributes::Invisible);
+    LMainCell->SetVisAttributes(grey);
+    //LMainCell->SetVisAttributes(G4VisAttributes::Invisible);
+    LExtCellU->SetVisAttributes(grey);
+    //LExtCellU->SetVisAttributes(G4VisAttributes::Invisible);
+    LExtCellD->SetVisAttributes(grey);
+    //LExtCellD->SetVisAttributes(G4VisAttributes::Invisible);
+    LMainCellEnd->SetVisAttributes(grey);
+    //LMainCellEnd->SetVisAttributes(G4VisAttributes::Invisible);
+    LBerylliumWindow->SetVisAttributes(lblue);
+    //LBerylliumWindow->SetVisAttributes(G4VisAttributes::Invisible);
+    fHeOutsideTeflonLogic->SetVisAttributes(cyan);
+    //fHeOutsideTeflonLogic->SetVisAttributes(G4VisAttributes::Invisible);
+
+    //------------------------------------------------------------------------------
+    //Create placements of the logical volumes
+    //------------------------------------------------------------------------------
+
+    //place main vessel
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0,0,0), //main vessel in the centre
+                       LMainCell,            //main cell logic
+                       "PMainCell",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       11,fIsOverlapVol);                  //copy number
+
+
+    //place main cell ends
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , ( fHeContainerZ/2 + fContainerThickness/2 ) ),
+                       LMainCellEnd,            //main cell end piece
+                       "PMainCellEnd1",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       12,fIsOverlapVol);                  //copy number
+
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness/2 ) ),
+                       LMainCellEnd,            //main cell end piece
+                       "PMainCellEnd2",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       13,fIsOverlapVol);                  //copy number
+
+
+    //place extension cells
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness + fExtensionZU/2 ) ),
+                       LExtCellU,            //extension cell logic
+                       "PExtCellU",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       14,fIsOverlapVol);                  //copy number
+
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , +( fHeContainerZ/2 + fContainerThickness + fExtensionZD/2 ) ),
+                       LExtCellD,            //extension cell logic
+                       "PExtCellD",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       15,fIsOverlapVol);                  //copy number
+
+
+    //place Be windows
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , -( fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness/2 ) ),
+                       LBerylliumWindow,            //beryllium window logic
+                       "PBeWindowU",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       16,fIsOverlapVol);                  //copy number
+
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , +( fHeContainerZ/2 + fContainerThickness + fExtensionZD + fBeThickness/2 ) ),
+                       LBerylliumWindow,            //beryllium window logic
+                       "PBeWindowD",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       17,fIsOverlapVol);                  //copy number
 
 } //end of MakeVessel()
 
@@ -376,18 +376,18 @@ void A2ActiveHe3::MakeVessel() {
 //-----------------------------------------------------------------------------------
 void A2ActiveHe3::MakeWLS()
 {
-  G4double th = 360.0*deg/fNwls;
-  G4double r0 = fHeContainerR - fRadClr;
-  fRwls1 = r0*cos(th/2) - 0.5*fWLSthick;
-  G4double z0 = fHeContainerZ/2 - fLatClr;
-  G4double d0 = r0*sin(th/2) - 0.001*mm; // slightly smaller so plates dont touch
-  G4double d1 = d0 - fWLSthick*tan(th/2);
-  G4Trd* wls = new G4Trd("WLS-bar", z0,z0,d0,d1,fWLSthick/2);
-  fWLSLogic = new G4LogicalVolume
-    (wls,fNistManager->FindOrBuildMaterial("G4_PLASTIC_SC_VINYLTOLUENE"),
-     "LogicWLS");
-  G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
-  fWLSLogic->SetVisAttributes(blue);
+    G4double th = 360.0*deg/fNwls;
+    G4double r0 = fHeContainerR - fRadClr;
+    fRwls1 = r0*cos(th/2) - 0.5*fWLSthick;
+    G4double z0 = fHeContainerZ/2 - fLatClr;
+    G4double d0 = r0*sin(th/2) - 0.001*mm; // slightly smaller so plates dont touch
+    G4double d1 = d0 - fWLSthick*tan(th/2);
+    G4Trd* wls = new G4Trd("WLS-bar", z0,z0,d0,d1,fWLSthick/2);
+    fWLSLogic = new G4LogicalVolume
+            (wls,fNistManager->FindOrBuildMaterial("G4_PLASTIC_SC_VINYLTOLUENE"),
+             "LogicWLS");
+    G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
+    fWLSLogic->SetVisAttributes(blue);
 }
 
 
@@ -399,46 +399,46 @@ it to member fPCBLogic
 **********************************************************/
 void A2ActiveHe3::MakePCB() {
 
-  //------------------------------------------------------------------------------
-  //Define parameter values
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Define parameter values
+    //------------------------------------------------------------------------------
 
-  fPCBThickness = 1.*mm;
-  fPCBRadius = fHeContainerR-4.5*mm; //define as a function of container R
-  fTeflonThicknessEnd = 1.*mm;
-  fPCBZ = fHeContainerZ - 20.*mm + 2*fTeflonThicknessEnd;
-  //------------------------------------------------------------------------------
-  //Define shapes (solids)
-  //------------------------------------------------------------------------------
+    fPCBThickness = 1.*mm;
+    fPCBRadius = fHeContainerR-4.5*mm; //define as a function of container R
+    fTeflonThicknessEnd = 1.*mm;
+    fPCBZ = fHeContainerZ - 20.*mm + 2*fTeflonThicknessEnd;
+    //------------------------------------------------------------------------------
+    //Define shapes (solids)
+    //------------------------------------------------------------------------------
 
-  //pcb is one cylinder
-  G4Tubs *PCB = new G4Tubs("PCB",
-  //			   fPCBRadius,                     //inner radius
-			   0,                     //inner radius
-			   fPCBRadius+fPCBThickness,       //outer radius
-			   fPCBZ/2,                  //length
-			   0.*deg,                         //start angle
-			   360.*deg);                      //final angle
+    //pcb is one cylinder
+    G4Tubs *PCB = new G4Tubs("PCB",
+                             //			   fPCBRadius,                     //inner radius
+                             0,                     //inner radius
+                             fPCBRadius+fPCBThickness,       //outer radius
+                             fPCBZ/2,                  //length
+                             0.*deg,                         //start angle
+                             360.*deg);                      //final angle
 
-  //------------------------------------------------------------------------------
-  //Define logical volumes
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Define logical volumes
+    //------------------------------------------------------------------------------
 
-  //invoke fPCBLogic
-  fPCBLogic = new G4LogicalVolume
-    (PCB,   //solid
-     fNistManager->FindOrBuildMaterial("G4_C"), //material
-     "LfPCBLogic");
+    //invoke fPCBLogic
+    fPCBLogic = new G4LogicalVolume
+            (PCB,   //solid
+             fNistManager->FindOrBuildMaterial("G4_C"), //material
+             "LfPCBLogic");
 
-  //------------------------------------------------------------------------------
-  //Set visual attributes
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Set visual attributes
+    //------------------------------------------------------------------------------
 
-  G4VisAttributes* lgreen = new G4VisAttributes( G4Colour(0.0,0.75,0.0) );
+    G4VisAttributes* lgreen = new G4VisAttributes( G4Colour(0.0,0.75,0.0) );
 
-  fPCBLogic->SetVisAttributes(lgreen);
+    fPCBLogic->SetVisAttributes(lgreen);
 
-  //fPCBLogic is placed inside fVesselLogic in function PlaceParts()
+    //fPCBLogic is placed inside fVesselLogic in function PlaceParts()
 } //end of MakePCB()
 
 
@@ -450,241 +450,241 @@ and places them to member fTeflanLogic
 **********************************************************/
 void A2ActiveHe3::MakeTeflonLayer() {
 
-  //------------------------------------------------------------------------------
-  //Define parameter values
-  //------------------------------------------------------------------------------
-  //fTeflonThicknessEnd = 1.*mm; //defined in MakePCB() to calculate pcb length
-  fTeflonThicknessCyl = 0.5*mm;
-  fTeflonR = fPCBRadius - fTeflonThicknessCyl; //reduced from original 95 to 70 mm, see doc
-  fTeflonZ = fPCBZ - 2*fTeflonThicknessEnd; //such length that teflonz+2endcaps=pcbz
-  fMylarThickness = 0.005*mm;
+    //------------------------------------------------------------------------------
+    //Define parameter values
+    //------------------------------------------------------------------------------
+    //fTeflonThicknessEnd = 1.*mm; //defined in MakePCB() to calculate pcb length
+    fTeflonThicknessCyl = 0.5*mm;
+    fTeflonR = fPCBRadius - fTeflonThicknessCyl; //reduced from original 95 to 70 mm, see doc
+    fTeflonZ = fPCBZ - 2*fTeflonThicknessEnd; //such length that teflonz+2endcaps=pcbz
+    fMylarThickness = 0.005*mm;
 
-  /*parameters for the flat parts on teflon cyl where the pmt's go
+    /*parameters for the flat parts on teflon cyl where the pmt's go
     the minimum flattening height depending on R was calculated as
-    h(fTeflonR) = fTeflonR - sqrt(fTeflonR^2 - (fPMTx/2)^2). The used 
+    h(fTeflonR) = fTeflonR - sqrt(fTeflonR^2 - (fPMTx/2)^2). The used
     number is more just in case. For h(R=95) = 0.047mm; h(R=46) = 0.098mm*/
-  fFlatteningWidth = 6*mm;
-  fFlatteningHeight = 0.12*mm;
- 
-  //------------------------------------------------------------------------------
-  //Define shapes (solids)
-  //------------------------------------------------------------------------------
+    fFlatteningWidth = 6*mm;
+    fFlatteningHeight = 0.12*mm;
 
-  G4Tubs *TeflonLogicCyl = new G4Tubs
-    ("TeflonLogicCyl",
-     0,                              //inner radius
-     fTeflonR+fTeflonThicknessCyl,   //outer radius
-     fPCBZ/2,                        //same length as pcb
-     0.*deg,                         //start angle
-     360.*deg);                      //final angle
-  
+    //------------------------------------------------------------------------------
+    //Define shapes (solids)
+    //------------------------------------------------------------------------------
 
-  //teflan cylinder covering pcb
-  G4Tubs *TeflonCyl = new G4Tubs("TeflonCyl",
-				 fTeflonR,                       //inner radius
-				 fTeflonR+fTeflonThicknessCyl,   //outer radius
-				 fTeflonZ/2,                     //length
-				 0.*deg,                         //start angle
-				 360.*deg);                      //final angle
-
-  G4Tubs *TeflonCylEnd = new G4Tubs("TeflonCylEnd",
-				    fExtensionR,                  //inner radius
-				    fTeflonR+fTeflonThicknessCyl, //outer radius
-				    fTeflonThicknessEnd/2,          //length
-				    0.*deg,                       //start angle
-				    360.*deg);                    //final angle
-
-  G4Tubs *MylarWindow = new G4Tubs("MylarWindow",
-				    0,                       //inner radius
-				    fExtensionR,             //outer radius
-				    fMylarThickness/2,          //length
-				    0.*deg,                  //start angle
-				    360.*deg);               //final angle
-
-  G4Box *Flattening = new G4Box("Flattening", fFlatteningWidth/2, fFlatteningHeight/2, fTeflonZ/2);
-
-  //create rotations
-  G4double theta = 90*deg;
-  G4ThreeVector u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
-  G4ThreeVector v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
-  G4ThreeVector w = G4ThreeVector(0, 0, 1);
-  G4RotationMatrix *rotz90  = new G4RotationMatrix(u, v, w);
-
-  theta = 45*deg;
-  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
-  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
-  w = G4ThreeVector(0, 0, 1);
-  G4RotationMatrix *rotz45  = new G4RotationMatrix(u, v, w);
-
-  theta = 135*deg;
-  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
-  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
-  w = G4ThreeVector(0, 0, 1);
-  G4RotationMatrix *rotz135  = new G4RotationMatrix(u, v, w);
-
-  G4UnionSolid* TefU1 = new G4UnionSolid
-    ("TefU1",
-     TeflonCyl,
-     Flattening,
-     rotz90,  
-     G4ThreeVector(fTeflonR-fFlatteningHeight/2, 0, 0) ); //move the flattening part
-
-  G4UnionSolid* TefU2 = new G4UnionSolid
-    ("TefU2",
-     TefU1,
-     Flattening,
-     rotz90, 
-     G4ThreeVector(-fTeflonR+fFlatteningHeight/2, 0, 0) ); //move the flattening part
-
-  G4UnionSolid* TefU3 = new G4UnionSolid
-    ("TefU3",
-     TefU2,
-     Flattening,
-     0, 
-     G4ThreeVector(0, fTeflonR-fFlatteningHeight/2, 0) ); //move the flattening part
-
-  G4UnionSolid* TefU4 = new G4UnionSolid
-    ("TefU4",
-     TefU3,
-     Flattening,
-     0, 
-     G4ThreeVector(0, -fTeflonR+fFlatteningHeight/2, 0) ); //move the flattening part
+    G4Tubs *TeflonLogicCyl = new G4Tubs
+            ("TeflonLogicCyl",
+             0,                              //inner radius
+             fTeflonR+fTeflonThicknessCyl,   //outer radius
+             fPCBZ/2,                        //same length as pcb
+             0.*deg,                         //start angle
+             360.*deg);                      //final angle
 
 
-  G4UnionSolid* TefU5 = new G4UnionSolid
-    ("TefU5",
-     TefU4,
-     Flattening,
-     rotz45,  
-     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    //teflan cylinder covering pcb
+    G4Tubs *TeflonCyl = new G4Tubs("TeflonCyl",
+                                   fTeflonR,                       //inner radius
+                                   fTeflonR+fTeflonThicknessCyl,   //outer radius
+                                   fTeflonZ/2,                     //length
+                                   0.*deg,                         //start angle
+                                   360.*deg);                      //final angle
 
-  G4UnionSolid* TefU6 = new G4UnionSolid
-    ("TefU6",
-     TefU5,
-     Flattening,
-     rotz45, 
-     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4Tubs *TeflonCylEnd = new G4Tubs("TeflonCylEnd",
+                                      fExtensionR,                  //inner radius
+                                      fTeflonR+fTeflonThicknessCyl, //outer radius
+                                      fTeflonThicknessEnd/2,          //length
+                                      0.*deg,                       //start angle
+                                      360.*deg);                    //final angle
 
-  G4UnionSolid* TefU7 = new G4UnionSolid
-    ("TefU7",
-     TefU6,
-     Flattening,
-     rotz135,  
-     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4Tubs *MylarWindow = new G4Tubs("MylarWindow",
+                                     0,                       //inner radius
+                                     fExtensionR,             //outer radius
+                                     fMylarThickness/2,          //length
+                                     0.*deg,                  //start angle
+                                     360.*deg);               //final angle
 
-  G4UnionSolid* TefU8 = new G4UnionSolid
-    ("TefU8",
-     TefU7,
-     Flattening,
-     rotz135, 
-     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4Box *Flattening = new G4Box("Flattening", fFlatteningWidth/2, fFlatteningHeight/2, fTeflonZ/2);
+
+    //create rotations
+    G4double theta = 90*deg;
+    G4ThreeVector u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+    G4ThreeVector v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+    G4ThreeVector w = G4ThreeVector(0, 0, 1);
+    G4RotationMatrix *rotz90  = new G4RotationMatrix(u, v, w);
+
+    theta = 45*deg;
+    u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+    v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+    w = G4ThreeVector(0, 0, 1);
+    G4RotationMatrix *rotz45  = new G4RotationMatrix(u, v, w);
+
+    theta = 135*deg;
+    u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+    v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+    w = G4ThreeVector(0, 0, 1);
+    G4RotationMatrix *rotz135  = new G4RotationMatrix(u, v, w);
+
+    G4UnionSolid* TefU1 = new G4UnionSolid
+            ("TefU1",
+             TeflonCyl,
+             Flattening,
+             rotz90,
+             G4ThreeVector(fTeflonR-fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+    G4UnionSolid* TefU2 = new G4UnionSolid
+            ("TefU2",
+             TefU1,
+             Flattening,
+             rotz90,
+             G4ThreeVector(-fTeflonR+fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+    G4UnionSolid* TefU3 = new G4UnionSolid
+            ("TefU3",
+             TefU2,
+             Flattening,
+             0,
+             G4ThreeVector(0, fTeflonR-fFlatteningHeight/2, 0) ); //move the flattening part
+
+    G4UnionSolid* TefU4 = new G4UnionSolid
+            ("TefU4",
+             TefU3,
+             Flattening,
+             0,
+             G4ThreeVector(0, -fTeflonR+fFlatteningHeight/2, 0) ); //move the flattening part
+
+
+    G4UnionSolid* TefU5 = new G4UnionSolid
+            ("TefU5",
+             TefU4,
+             Flattening,
+             rotz45,
+             G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+    G4UnionSolid* TefU6 = new G4UnionSolid
+            ("TefU6",
+             TefU5,
+             Flattening,
+             rotz45,
+             G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+    G4UnionSolid* TefU7 = new G4UnionSolid
+            ("TefU7",
+             TefU6,
+             Flattening,
+             rotz135,
+             G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+
+    G4UnionSolid* TefU8 = new G4UnionSolid
+            ("TefU8",
+             TefU7,
+             Flattening,
+             rotz135,
+             G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
 
     
-  //he inside the teflon cylinder 
-  G4Tubs *HeTube = new G4Tubs("HeTube",
-				 0,                       //inner radius
-				 fTeflonR+fTeflonThicknessCyl,   //outer radius
-				 fTeflonZ/2,               // same length as teflon main cyl
-				 0.*deg,                         //start angle
-				 360.*deg);                      //final angle
+    //he inside the teflon cylinder
+    G4Tubs *HeTube = new G4Tubs("HeTube",
+                                0,                       //inner radius
+                                fTeflonR+fTeflonThicknessCyl,   //outer radius
+                                fTeflonZ/2,               // same length as teflon main cyl
+                                0.*deg,                         //start angle
+                                360.*deg);                      //final angle
 
-  //he gas = teflon main cyl (outer r) - teflon main cyl solid
-  G4SubtractionSolid* HeInsideTeflon = new G4SubtractionSolid
-    ("HeInsideTeflon",
-     HeTube,
-     TefU8 );
+    //he gas = teflon main cyl (outer r) - teflon main cyl solid
+    G4SubtractionSolid* HeInsideTeflon = new G4SubtractionSolid
+            ("HeInsideTeflon",
+             HeTube,
+             TefU8 );
 
-  //------------------------------------------------------------------------------
-  //Define logical volumes
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Define logical volumes
+    //------------------------------------------------------------------------------
 
-  //invoke fTeflonLogic
-  fTeflonLogic = new G4LogicalVolume
-    (TeflonLogicCyl,   //solid
-     //fNistManager->FindOrBuildMaterial("G4_AIR"), //material
-     fNistManager->FindOrBuildMaterial("ATGasMix"),
-     "LfTeflonLogic");
+    //invoke fTeflonLogic
+    fTeflonLogic = new G4LogicalVolume
+            (TeflonLogicCyl,   //solid
+             //fNistManager->FindOrBuildMaterial("G4_AIR"), //material
+             fNistManager->FindOrBuildMaterial("ATGasMix"),
+             "LfTeflonLogic");
 
-  fTeflonCylLogic = new G4LogicalVolume
-    (TefU8,   //solid
-     fNistManager->FindOrBuildMaterial("ATTeflon"), //material
-     "LTeflonCyl");
-  
-  fTeflonCylEndLogic = new G4LogicalVolume
-    (TeflonCylEnd,   //solid
-     fNistManager->FindOrBuildMaterial("ATTeflon"), //material
-     "LTeflonCylEnd");
+    fTeflonCylLogic = new G4LogicalVolume
+            (TefU8,   //solid
+             fNistManager->FindOrBuildMaterial("ATTeflon"), //material
+             "LTeflonCyl");
 
-  fMylarLogic = new G4LogicalVolume
-    (MylarWindow,   //solid
-     fNistManager->FindOrBuildMaterial("ATMylarW"), //material
-     "LMylarWindow");
+    fTeflonCylEndLogic = new G4LogicalVolume
+            (TeflonCylEnd,   //solid
+             fNistManager->FindOrBuildMaterial("ATTeflon"), //material
+             "LTeflonCylEnd");
 
-  fHeInsideTeflonLogic = new G4LogicalVolume
-    (HeInsideTeflon,   //solid
-     fNistManager->FindOrBuildMaterial("ATGasMix"), //material
-     "LHeInsideTeflon");
+    fMylarLogic = new G4LogicalVolume
+            (MylarWindow,   //solid
+             fNistManager->FindOrBuildMaterial("ATMylarW"), //material
+             "LMylarWindow");
 
-  //------------------------------------------------------------------------------
-  //Set visual attributes
-  //------------------------------------------------------------------------------
+    fHeInsideTeflonLogic = new G4LogicalVolume
+            (HeInsideTeflon,   //solid
+             fNistManager->FindOrBuildMaterial("ATGasMix"), //material
+             "LHeInsideTeflon");
 
-  G4VisAttributes* red    = new G4VisAttributes( G4Colour(0.3,0.0,0.0)  );
-  G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
-  G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
+    //------------------------------------------------------------------------------
+    //Set visual attributes
+    //------------------------------------------------------------------------------
 
-  fTeflonLogic->SetVisAttributes(G4VisAttributes::Invisible);
-  fTeflonCylLogic ->SetVisAttributes(red);
-  fTeflonCylEndLogic->SetVisAttributes(red);
-  fMylarLogic->SetVisAttributes(blue);
-  fHeInsideTeflonLogic->SetVisAttributes(cyan);
+    G4VisAttributes* red    = new G4VisAttributes( G4Colour(0.3,0.0,0.0)  );
+    G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
+    G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
 
-  //------------------------------------------------------------------------------
-  //Create placements of the logical volumes
-  //------------------------------------------------------------------------------
-  
-  //place the teflon cylinder
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0,0,0), //teflon cylinder in the centre
-		     fTeflonCylLogic,                 //teflon cylinder logic
-		     "PTeflonCyl",               //name
-		     fTeflonLogic,            //mother logic (teflonLogic)
-		     false,                //pMany = false, true is not implemented
-		     31,fIsOverlapVol);                  //copy number 
+    fTeflonLogic->SetVisAttributes(G4VisAttributes::Invisible);
+    fTeflonCylLogic ->SetVisAttributes(red);
+    fTeflonCylEndLogic->SetVisAttributes(red);
+    fMylarLogic->SetVisAttributes(blue);
+    fHeInsideTeflonLogic->SetVisAttributes(cyan);
 
-  //place cylinder end walls
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , ( fTeflonZ/2 + fTeflonThicknessEnd/2 ) ),
-		     fTeflonCylEndLogic,            //main cell end piece
-		     "PTeflonCylEnd1",          //name
-		     fTeflonLogic,         //mother logic (teflonLogic)
-		     false,                //pMany = false, true is not implemented
-		     32,fIsOverlapVol);                  //copy number 
+    //------------------------------------------------------------------------------
+    //Create placements of the logical volumes
+    //------------------------------------------------------------------------------
 
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , -( fTeflonZ/2 + fTeflonThicknessEnd/2 ) ),
-		     fTeflonCylEndLogic,            //main cell end piece
-		     "PTeflonCylEnd2",          //name
-		     fTeflonLogic,         //mother logic (teflonLogic)
-		     false,                //pMany = false, true is not implemented
-		     33,fIsOverlapVol);                  //copy number 
+    //place the teflon cylinder
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0,0,0), //teflon cylinder in the centre
+                       fTeflonCylLogic,                 //teflon cylinder logic
+                       "PTeflonCyl",               //name
+                       fTeflonLogic,            //mother logic (teflonLogic)
+                       false,                //pMany = false, true is not implemented
+                       31,fIsOverlapVol);                  //copy number
 
-  //place the mylar windows
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , ( fTeflonZ/2 + fMylarThickness/2 ) ),
-		     fMylarLogic,            //mylar window
-		     "PMylarWindow1",          //name
-		     fTeflonLogic,         //mother logic (teflonLogic)
-		     false,                //pMany = false, true is not implemented
-		     34,fIsOverlapVol);                  //copy number 
+    //place cylinder end walls
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , ( fTeflonZ/2 + fTeflonThicknessEnd/2 ) ),
+                       fTeflonCylEndLogic,            //main cell end piece
+                       "PTeflonCylEnd1",          //name
+                       fTeflonLogic,         //mother logic (teflonLogic)
+                       false,                //pMany = false, true is not implemented
+                       32,fIsOverlapVol);                  //copy number
 
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0 , -( fTeflonZ/2 + fMylarThickness/2 ) ),
-		     fMylarLogic,            //mylar window
-		     "PMylarWindow2",          //name
-		     fTeflonLogic,         //mother logic (teflonLogic)
-		     false,                //pMany = false, true is not implemented
-		     35,fIsOverlapVol);                  //copy number 
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , -( fTeflonZ/2 + fTeflonThicknessEnd/2 ) ),
+                       fTeflonCylEndLogic,            //main cell end piece
+                       "PTeflonCylEnd2",          //name
+                       fTeflonLogic,         //mother logic (teflonLogic)
+                       false,                //pMany = false, true is not implemented
+                       33,fIsOverlapVol);                  //copy number
+
+    //place the mylar windows
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , ( fTeflonZ/2 + fMylarThickness/2 ) ),
+                       fMylarLogic,            //mylar window
+                       "PMylarWindow1",          //name
+                       fTeflonLogic,         //mother logic (teflonLogic)
+                       false,                //pMany = false, true is not implemented
+                       34,fIsOverlapVol);                  //copy number
+
+    new G4PVPlacement (0,  //no rotation
+                       G4ThreeVector(0, 0 , -( fTeflonZ/2 + fMylarThickness/2 ) ),
+                       fMylarLogic,            //mylar window
+                       "PMylarWindow2",          //name
+                       fTeflonLogic,         //mother logic (teflonLogic)
+                       false,                //pMany = false, true is not implemented
+                       35,fIsOverlapVol);                  //copy number
 
 } //end of MakeTeflonLayer()
 
@@ -702,156 +702,156 @@ to mylar thickness
 **********************************************************/
 void A2ActiveHe3::MakeMylarSections(G4int nrofsections) {
 
-  //---------------------------------------------------------------------------
-  //Define parameters
-  //---------------------------------------------------------------------------
-  fMylarSecZ = 0.005*mm;
+    //---------------------------------------------------------------------------
+    //Define parameters
+    //---------------------------------------------------------------------------
+    fMylarSecZ = 0.005*mm;
 
-  if (nrofsections == 8) {
-    G4cout << "A2ActiveHe3::MakeMylarSections() Sectioning active target to 8." << G4endl;
-    fMylarWinStep = 50.*mm;          //values with 8 sections
-    fMylarWinOffset = 50.*mm;
-    fNMylarSecWins = 7;
-  }
-  else if (nrofsections == 4) {
-    G4cout << "A2ActiveHe3::MakeMylarSections() Sectioning active target to 4." << G4endl;
-    fMylarWinStep = 100.*mm;         //values with 4 sections
-    fMylarWinOffset = 100.*mm;
-    fNMylarSecWins = 3;
-  }
-  else {
-    G4cout << "A2ActiveHe3::MakeMylarSections() Unsupported number of active target sections defined, the target will not be sectioned." << G4endl;
-    return;
-  }
+    if (nrofsections == 8) {
+        G4cout << "A2ActiveHe3::MakeMylarSections() Sectioning active target to 8." << G4endl;
+        fMylarWinStep = 50.*mm;          //values with 8 sections
+        fMylarWinOffset = 50.*mm;
+        fNMylarSecWins = 7;
+    }
+    else if (nrofsections == 4) {
+        G4cout << "A2ActiveHe3::MakeMylarSections() Sectioning active target to 4." << G4endl;
+        fMylarWinStep = 100.*mm;         //values with 4 sections
+        fMylarWinOffset = 100.*mm;
+        fNMylarSecWins = 3;
+    }
+    else {
+        G4cout << "A2ActiveHe3::MakeMylarSections() Unsupported number of active target sections defined, the target will not be sectioned." << G4endl;
+        return;
+    }
 
-  //------------------------------------------------------------------------------
-  //Create solid
-  //------------------------------------------------------------------------------
-  G4Tubs *MylarSecOuter = new G4Tubs("MylarSecOuter",
-				     fTeflonR,                       //inner radius
-				     fTeflonR+fTeflonThicknessCyl,   //outer radius
-				     fMylarSecZ/2,                     //length
-				     0.*deg,                         //start angle
-				     360.*deg);                      //final angle
-  
-  G4Box *MylarSecFlattening = new G4Box("MylarSecFlattening", fFlatteningWidth/2, fFlatteningHeight/2, fMylarSecZ/2);
-  
-  //create rotations
-  G4double theta = 90*deg;
-  G4ThreeVector u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
-  G4ThreeVector v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
-  G4ThreeVector w = G4ThreeVector(0, 0, 1);
-  G4RotationMatrix *rotz90  = new G4RotationMatrix(u, v, w);
+    //------------------------------------------------------------------------------
+    //Create solid
+    //------------------------------------------------------------------------------
+    G4Tubs *MylarSecOuter = new G4Tubs("MylarSecOuter",
+                                       fTeflonR,                       //inner radius
+                                       fTeflonR+fTeflonThicknessCyl,   //outer radius
+                                       fMylarSecZ/2,                     //length
+                                       0.*deg,                         //start angle
+                                       360.*deg);                      //final angle
 
-  theta = 45*deg;
-  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
-  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
-  w = G4ThreeVector(0, 0, 1);
-  G4RotationMatrix *rotz45  = new G4RotationMatrix(u, v, w);
+    G4Box *MylarSecFlattening = new G4Box("MylarSecFlattening", fFlatteningWidth/2, fFlatteningHeight/2, fMylarSecZ/2);
 
-  theta = 135*deg;
-  u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
-  v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
-  w = G4ThreeVector(0, 0, 1);
-  G4RotationMatrix *rotz135  = new G4RotationMatrix(u, v, w);
+    //create rotations
+    G4double theta = 90*deg;
+    G4ThreeVector u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+    G4ThreeVector v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+    G4ThreeVector w = G4ThreeVector(0, 0, 1);
+    G4RotationMatrix *rotz90  = new G4RotationMatrix(u, v, w);
 
-  G4UnionSolid* MylU1 = new G4UnionSolid
-    ("MylU1",
-     MylarSecOuter,
-     MylarSecFlattening,
-     rotz90,  
-     G4ThreeVector(fTeflonR-fFlatteningHeight/2, 0, 0) ); //move the flattening part
+    theta = 45*deg;
+    u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+    v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+    w = G4ThreeVector(0, 0, 1);
+    G4RotationMatrix *rotz45  = new G4RotationMatrix(u, v, w);
 
-  G4UnionSolid* MylU2 = new G4UnionSolid
-    ("MylU2",
-     MylU1,
-     MylarSecFlattening,
-     rotz90, 
-     G4ThreeVector(-fTeflonR+fFlatteningHeight/2, 0, 0) ); //move the flattening part
+    theta = 135*deg;
+    u = G4ThreeVector(std::cos(theta), -std::sin(theta), 0);
+    v = G4ThreeVector(std::sin(theta), std::cos(theta), 0);
+    w = G4ThreeVector(0, 0, 1);
+    G4RotationMatrix *rotz135  = new G4RotationMatrix(u, v, w);
 
-  G4UnionSolid* MylU3 = new G4UnionSolid
-    ("MylU3",
-     MylU2,
-     MylarSecFlattening,
-     0, 
-     G4ThreeVector(0, fTeflonR-fFlatteningHeight/2, 0) ); //move the flattening part
+    G4UnionSolid* MylU1 = new G4UnionSolid
+            ("MylU1",
+             MylarSecOuter,
+             MylarSecFlattening,
+             rotz90,
+             G4ThreeVector(fTeflonR-fFlatteningHeight/2, 0, 0) ); //move the flattening part
 
-  G4UnionSolid* MylU4 = new G4UnionSolid
-    ("MylU4",
-     MylU3,
-     MylarSecFlattening,
-     0, 
-     G4ThreeVector(0, -fTeflonR+fFlatteningHeight/2, 0) ); //move the flattening part
+    G4UnionSolid* MylU2 = new G4UnionSolid
+            ("MylU2",
+             MylU1,
+             MylarSecFlattening,
+             rotz90,
+             G4ThreeVector(-fTeflonR+fFlatteningHeight/2, 0, 0) ); //move the flattening part
+
+    G4UnionSolid* MylU3 = new G4UnionSolid
+            ("MylU3",
+             MylU2,
+             MylarSecFlattening,
+             0,
+             G4ThreeVector(0, fTeflonR-fFlatteningHeight/2, 0) ); //move the flattening part
+
+    G4UnionSolid* MylU4 = new G4UnionSolid
+            ("MylU4",
+             MylU3,
+             MylarSecFlattening,
+             0,
+             G4ThreeVector(0, -fTeflonR+fFlatteningHeight/2, 0) ); //move the flattening part
 
 
-  G4UnionSolid* MylU5 = new G4UnionSolid
-    ("MylU5",
-     MylU4,
-     MylarSecFlattening,
-     rotz45,  
-     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4UnionSolid* MylU5 = new G4UnionSolid
+            ("MylU5",
+             MylU4,
+             MylarSecFlattening,
+             rotz45,
+             G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
 
-  G4UnionSolid* MylU6 = new G4UnionSolid
-    ("MylU6",
-     MylU5,
-     MylarSecFlattening,
-     rotz45, 
-     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4UnionSolid* MylU6 = new G4UnionSolid
+            ("MylU6",
+             MylU5,
+             MylarSecFlattening,
+             rotz45,
+             G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
 
-  G4UnionSolid* MylU7 = new G4UnionSolid
-    ("MylU7",
-     MylU6,
-     MylarSecFlattening,
-     rotz135,  
-     G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4UnionSolid* MylU7 = new G4UnionSolid
+            ("MylU7",
+             MylU6,
+             MylarSecFlattening,
+             rotz135,
+             G4ThreeVector( -(fTeflonR-fFlatteningHeight/2)/sqrt(2), -(fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
 
-  G4UnionSolid* MylU8 = new G4UnionSolid
-    ("MylU8",
-     MylU7,
-     MylarSecFlattening,
-     rotz135, 
-     G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
+    G4UnionSolid* MylU8 = new G4UnionSolid
+            ("MylU8",
+             MylU7,
+             MylarSecFlattening,
+             rotz135,
+             G4ThreeVector( (fTeflonR-fFlatteningHeight/2)/sqrt(2), (fTeflonR-fFlatteningHeight/2)/sqrt(2), 0) );
 
     
-  //mylar inside the teflon cylinder 
-  G4Tubs *MylarSec = new G4Tubs("MylarSec",
-				 0,                       //inner radius
-				 fTeflonR+fTeflonThicknessCyl,   //outer radius
-				 fMylarSecZ/2,               
-				 0.*deg,                         //start angle
-				 360.*deg);                      //final angle
+    //mylar inside the teflon cylinder
+    G4Tubs *MylarSec = new G4Tubs("MylarSec",
+                                  0,                       //inner radius
+                                  fTeflonR+fTeflonThicknessCyl,   //outer radius
+                                  fMylarSecZ/2,
+                                  0.*deg,                         //start angle
+                                  360.*deg);                      //final angle
 
-  //create the actual solid
-  G4SubtractionSolid* MylarInsideTeflon = new G4SubtractionSolid
-    ("MylarInsideTeflon",
-     MylarSec,
-     MylU8 );
+    //create the actual solid
+    G4SubtractionSolid* MylarInsideTeflon = new G4SubtractionSolid
+            ("MylarInsideTeflon",
+             MylarSec,
+             MylU8 );
 
-  //------------------------------------------------------------------------------
-  //Create logical volume
-  //------------------------------------------------------------------------------
-  fMylarSectionLogic = new G4LogicalVolume
-    (MylarInsideTeflon,
-     fNistManager->FindOrBuildMaterial("ATMylarW"),
-     "LMylarSection");
+    //------------------------------------------------------------------------------
+    //Create logical volume
+    //------------------------------------------------------------------------------
+    fMylarSectionLogic = new G4LogicalVolume
+            (MylarInsideTeflon,
+             fNistManager->FindOrBuildMaterial("ATMylarW"),
+             "LMylarSection");
 
-  //------------------------------------------------------------------------------
-  //Create placements of the logical volumes
-  //------------------------------------------------------------------------------
-  G4int nwindows;
-  for (nwindows = 0; nwindows < fNMylarSecWins; nwindows++) {
+    //------------------------------------------------------------------------------
+    //Create placements of the logical volumes
+    //------------------------------------------------------------------------------
+    G4int nwindows;
+    for (nwindows = 0; nwindows < fNMylarSecWins; nwindows++) {
 
-    //place the mylar sectioning windows along z
-    new G4PVPlacement 
-      (0,
-       G4ThreeVector(0, 0, -fTeflonZ/2 + fMylarWinOffset + nwindows*fMylarWinStep),
-       fMylarSectionLogic,
-       "PMylarSection",                  //name
-       fHeInsideTeflonLogic,            //mother logic 
-       false,                   //pMany = false, true is not implemented
-       200+nwindows,fIsOverlapVol);                  //copy number 
-      
-  } //end of for loop for mylar windows placement
+        //place the mylar sectioning windows along z
+        new G4PVPlacement
+                (0,
+                 G4ThreeVector(0, 0, -fTeflonZ/2 + fMylarWinOffset + nwindows*fMylarWinStep),
+                 fMylarSectionLogic,
+                 "PMylarSection",                  //name
+                 fHeInsideTeflonLogic,            //mother logic
+                 false,                   //pMany = false, true is not implemented
+                 200+nwindows,fIsOverlapVol);                  //copy number
+
+    } //end of for loop for mylar windows placement
 
 } //end MakeMylarSections()
 
@@ -866,99 +866,99 @@ detector inside fMyLogic
 **********************************************************/
 void A2ActiveHe3::PlaceParts() {
 
-  //------------------------------------------------------------------------------
-  //Define shape for fMyLogic and construct it (simple cylinder that
-  //has room for everything)
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Define shape for fMyLogic and construct it (simple cylinder that
+    //has room for everything)
+    //------------------------------------------------------------------------------
 
-  G4Tubs *MyLogicCyl = new G4Tubs
-    ("MyLogicCyl",
-     0,                              //inner radius
-     fHeContainerR+fContainerThickness,   //outer radius
-     fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness,
-     0.*deg,                         //start angle
-     360.*deg);                      //final angle
+    G4Tubs *MyLogicCyl = new G4Tubs
+            ("MyLogicCyl",
+             0,                              //inner radius
+             fHeContainerR+fContainerThickness,   //outer radius
+             fHeContainerZ/2 + fContainerThickness + fExtensionZU + fBeThickness,
+             0.*deg,                         //start angle
+             360.*deg);                      //final angle
 
-  fMyLogic = new G4LogicalVolume
-    (MyLogicCyl,                                  //solid
-     fNistManager->FindOrBuildMaterial("G4_AIR"), //material
-     "LfMyLogic");                                //name
+    fMyLogic = new G4LogicalVolume
+            (MyLogicCyl,                                  //solid
+             fNistManager->FindOrBuildMaterial("G4_AIR"), //material
+             "LfMyLogic");                                //name
 
-  fMyLogic->SetVisAttributes(G4VisAttributes::Invisible);  
+    fMyLogic->SetVisAttributes(G4VisAttributes::Invisible);
 
-  //------------------------------------------------------------------------------
-  //Place parts of the detector
-  //------------------------------------------------------------------------------
-  if(!fIsWLS){
-    //place the helium inside teflon cylinder
+    //------------------------------------------------------------------------------
+    //Place parts of the detector
+    //------------------------------------------------------------------------------
+    if(!fIsWLS){
+        //place the helium inside teflon cylinder
+        new G4PVPlacement (0,  //no rotation
+                           G4ThreeVector(0,0,0), //teflon cylinder in the centre
+                           fHeInsideTeflonLogic,     //helium logic
+                           "PHeInsideTeflon",        //name
+                           fTeflonLogic,            //mother logic (teflonLogic)
+                           false,                //pMany = false, true is not implemented
+                           45,fIsOverlapVol);                  //copy number
+
+        //place the teflon layer insice pcb
+        new G4PVPlacement (0,                    //no rotation
+                           G4ThreeVector(0,0,0), //center
+                           fTeflonLogic,         //main cell logic
+                           "PTeflonLogic",       //name
+                           fPCBLogic,             //mother logic
+                           false,                //pMany = false, true is not implemented
+                           44,fIsOverlapVol);                  //copy number
+
+        //place the pcb inside the outside helium
+        new G4PVPlacement (0,                    //no rotation
+                           G4ThreeVector(0,0,0), //center
+                           fPCBLogic,            //main cell logic
+                           "PPCBLogic",          //name
+                           fHeOutsideTeflonLogic,//mother logic
+                           false,                //pMany = false, true is not implemented
+                           43,fIsOverlapVol);    //copy number
+    }
+    //place the outside helium inside vessel
     new G4PVPlacement (0,  //no rotation
-		       G4ThreeVector(0,0,0), //teflon cylinder in the centre
-		       fHeInsideTeflonLogic,     //helium logic
-		       "PHeInsideTeflon",        //name
-		       fTeflonLogic,            //mother logic (teflonLogic)
-		       false,                //pMany = false, true is not implemented
-		       45,fIsOverlapVol);                  //copy number 
-    
-    //place the teflon layer insice pcb
-    new G4PVPlacement (0,                    //no rotation
-		       G4ThreeVector(0,0,0), //center
-		       fTeflonLogic,         //main cell logic
-		       "PTeflonLogic",       //name
-		       fPCBLogic,             //mother logic
-		       false,                //pMany = false, true is not implemented
-		       44,fIsOverlapVol);                  //copy number
+                       G4ThreeVector(0, 0, 0),
+                       fHeOutsideTeflonLogic,            //he gas logic
+                       "PHeOutsideTeflon",          //name
+                       fVesselLogic,         //mother logic (vessel)
+                       false,                //pMany = false, true is not implemented
+                       42,fIsOverlapVol);                  //copy number
+    //
+    // place WLS plates in He gas volume
+    // loop round phi segments (sides of polygon)
+    // NB copy numbers provisionally set 140 onwards...this may have to change
+    //
+    G4double th = 360*deg/fNwls;
+    G4double th2 = 0.0;
+    for(G4int iw=0; iw<fNwls; iw++){
+        G4RotationMatrix* pp = new G4RotationMatrix();
+        G4double th1 = iw*th;
+        pp->rotateY(90*deg);            // align parallel beam axis
+        pp->rotateX(th1);               // align for side of polygon
+        G4double xw = fRwls1*cos(th2);  // coordinates for polygon side
+        G4double yw = fRwls1*sin(th2);
+        char nw[16];
+        sprintf(nw,"PWLS_%d",iw);
+        new G4PVPlacement (pp,
+                           G4ThreeVector(xw, yw, 0),
+                           fWLSLogic,
+                           nw,
+                           fHeOutsideTeflonLogic,//mother logic (He)
+                           false,                //pMany = false
+                           iw,fIsOverlapVol);    //copy number
+        th2 -= th;
+    }
 
-    //place the pcb inside the outside helium
+    //place the vessel inside MyLogic
     new G4PVPlacement (0,                    //no rotation
-		       G4ThreeVector(0,0,0), //center
-		       fPCBLogic,            //main cell logic
-		       "PPCBLogic",          //name
-		       fHeOutsideTeflonLogic,//mother logic
-		       false,                //pMany = false, true is not implemented
-		       43,fIsOverlapVol);    //copy number
-  }
-  //place the outside helium inside vessel
-  new G4PVPlacement (0,  //no rotation
-		     G4ThreeVector(0, 0, 0),
-		     fHeOutsideTeflonLogic,            //he gas logic
-		     "PHeOutsideTeflon",          //name
-		     fVesselLogic,         //mother logic (vessel)
-		     false,                //pMany = false, true is not implemented
-		     42,fIsOverlapVol);                  //copy number
-  //
-  // place WLS plates in He gas volume
-  // loop round phi segments (sides of polygon)
-  // NB copy numbers provisionally set 140 onwards...this may have to change
-  // 
-  G4double th = 360*deg/fNwls;
-  G4double th2 = 0.0;
-  for(G4int iw=0; iw<fNwls; iw++){
-    G4RotationMatrix* pp = new G4RotationMatrix();
-    G4double th1 = iw*th;
-    pp->rotateY(90*deg);            // align parallel beam axis
-    pp->rotateX(th1);               // align for side of polygon
-    G4double xw = fRwls1*cos(th2);  // coordinates for polygon side
-    G4double yw = fRwls1*sin(th2);
-    char nw[16];
-    sprintf(nw,"PWLS_%d",iw);
-    new G4PVPlacement (pp,
-		       G4ThreeVector(xw, yw, 0),
-		       fWLSLogic,         
-		       nw,     
-		       fHeOutsideTeflonLogic,//mother logic (He)
-		       false,                //pMany = false
-		       140+iw,fIsOverlapVol);    //copy number
-    th2 -= th;
-  }
-
-  //place the vessel inside MyLogic
-  new G4PVPlacement (0,                    //no rotation
-  		     G4ThreeVector(0,0,0), //center
-  		     fVesselLogic,         //main cell logic
-  		     "PVesselLogic",       //name
-  		     fMyLogic,             //mother logic
-  		     false,                //pMany = false, true is not implemented
-  		     41,fIsOverlapVol);    //copy number
+                       G4ThreeVector(0,0,0), //center
+                       fVesselLogic,         //main cell logic
+                       "PVesselLogic",       //name
+                       fMyLogic,             //mother logic
+                       false,                //pMany = false, true is not implemented
+                       41,fIsOverlapVol);    //copy number
 
 }
 
@@ -971,359 +971,356 @@ for some materials and surfaces
 **********************************************************/
 void A2ActiveHe3::SetOpticalProperties() {
 
-  //------------------------------------------------------------------------------
-  //gas mixture
-  //------------------------------------------------------------------------------
-  const G4int nentries = 18;
+    //------------------------------------------------------------------------------
+    //gas mixture
+    //------------------------------------------------------------------------------
+    const G4int nentries = 18;
 
-  //Photon energies 1.88 - 3.87 eV --> 660 - 320 nm, even step of 20 nm
-  G4double HeN_Energy[nentries] = {1.88*eV, 1.94*eV, 2.0*eV, 2.07*eV, 2.14*eV, 2.21*eV, 2.3*eV,
-				   2.38*eV, 2.48*eV, 2.58*eV, 2.7*eV, 2.82*eV, 2.95*eV, 3.1*eV,
-				   3.26*eV, 3.44*eV, 3.65*eV, 3.87*eV};
+    //Photon energies 1.88 - 3.87 eV --> 660 - 320 nm, even step of 20 nm
+    G4double HeN_Energy[nentries] = {1.88*eV, 1.94*eV, 2.0*eV, 2.07*eV, 2.14*eV, 2.21*eV, 2.3*eV,
+                                     2.38*eV, 2.48*eV, 2.58*eV, 2.7*eV, 2.82*eV, 2.95*eV, 3.1*eV,
+                                     3.26*eV, 3.44*eV, 3.65*eV, 3.87*eV};
 
-  //this gives a peak from 400 to 440 nm --> 3.1 to 2.95 eV
-  G4double HeN_SCINT[nentries] = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-				  0.1, 0.1, 0.1, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1};
+    //this gives a peak from 400 to 440 nm --> 3.1 to 2.95 eV
+    G4double HeN_SCINT[nentries] = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+                                    0.1, 0.1, 0.1, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1};
 
-  //See ref in Seian's paper; no need for higher accuracy in my opinion
-  G4double HeN_RIND[nentries] =
+    //See ref in Seian's paper; no need for higher accuracy in my opinion
+    G4double HeN_RIND[nentries] =
     {1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003,
-     1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003}; 
+     1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003, 1.00003};
 
-  //absorption length  
-  G4double HeN_ABSL[nentries] = 
+    //absorption length
+    G4double HeN_ABSL[nentries] =
     {3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm, 3500.*cm,
      3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm,3500.*cm, 3500.*cm};
-  
-  G4MaterialPropertiesTable* HeN_mt = new G4MaterialPropertiesTable();
-  HeN_mt->AddProperty("FASTCOMPONENT", HeN_Energy, HeN_SCINT, nentries);
-  HeN_mt->AddProperty("SLOWCOMPONENT", HeN_Energy, HeN_SCINT, nentries);
-  HeN_mt->AddProperty("RINDEX",        HeN_Energy, HeN_RIND,  nentries);
-  HeN_mt->AddProperty("ABSLENGTH",     HeN_Energy, HeN_ABSL,  nentries);
 
-  HeN_mt->AddConstProperty("SCINTILLATIONYIELD", fScintYield/MeV   );    
-  HeN_mt->AddConstProperty("RESOLUTIONSCALE" ,   1.0        );  
+    G4MaterialPropertiesTable* HeN_mt = new G4MaterialPropertiesTable();
+    HeN_mt->AddProperty("FASTCOMPONENT", HeN_Energy, HeN_SCINT, nentries);
+    HeN_mt->AddProperty("SLOWCOMPONENT", HeN_Energy, HeN_SCINT, nentries);
+    HeN_mt->AddProperty("RINDEX",        HeN_Energy, HeN_RIND,  nentries);
+    HeN_mt->AddProperty("ABSLENGTH",     HeN_Energy, HeN_ABSL,  nentries);
 
-  //numbers from Jonh's optical simulation--------------
-  // HeN_mt->AddConstProperty("FASTTIMECONSTANT",20.*ns);
-  // HeN_mt->AddConstProperty("SLOWTIMECONSTANT",45.*ns);
-  // HeN_mt->AddConstProperty("YIELDRATIO",1.0);
+    HeN_mt->AddConstProperty("SCINTILLATIONYIELD", fScintYield/MeV   );
+    HeN_mt->AddConstProperty("RESOLUTIONSCALE" ,   1.0        );
 
-  //numbers from Active target simulation with gdml file
-  // HeN_mt->AddConstProperty("FASTTIMECONSTANT",   0.5*ns     );// 8  ns  20
-  // HeN_mt->AddConstProperty("SLOWTIMECONSTANT",   23.*ns     );// 23 ns  45
-  // HeN_mt->AddConstProperty("YIELDRATIO",         0.5        );
+    //numbers from Jonh's optical simulation--------------
+    // HeN_mt->AddConstProperty("FASTTIMECONSTANT",20.*ns);
+    // HeN_mt->AddConstProperty("SLOWTIMECONSTANT",45.*ns);
+    // HeN_mt->AddConstProperty("YIELDRATIO",1.0);
 
-  //numbers according to Seian's thesis-----------------
-  HeN_mt->AddConstProperty("FASTTIMECONSTANT",   30.*ns     );
-  HeN_mt->AddConstProperty("SLOWTIMECONSTANT",   60.*ns     );
-  HeN_mt->AddConstProperty("YIELDRATIO",         1.0        );
-  //----------------------------------------------------
+    //numbers from Active target simulation with gdml file
+    // HeN_mt->AddConstProperty("FASTTIMECONSTANT",   0.5*ns     );// 8  ns  20
+    // HeN_mt->AddConstProperty("SLOWTIMECONSTANT",   23.*ns     );// 23 ns  45
+    // HeN_mt->AddConstProperty("YIELDRATIO",         0.5        );
 
-  //add these properties to GasMix
-  fNistManager->FindOrBuildMaterial("ATGasMix")->SetMaterialPropertiesTable(HeN_mt);
+    //numbers according to Seian's thesis-----------------
+    HeN_mt->AddConstProperty("FASTTIMECONSTANT",   30.*ns     );
+    HeN_mt->AddConstProperty("SLOWTIMECONSTANT",   60.*ns     );
+    HeN_mt->AddConstProperty("YIELDRATIO",         1.0        );
+    //----------------------------------------------------
 
-  //------------------------------------------------------------------------------
-  //teflon properties
-  //------------------------------------------------------------------------------
+    //add these properties to GasMix
+    fNistManager->FindOrBuildMaterial("ATGasMix")->SetMaterialPropertiesTable(HeN_mt);
 
-  //PTFE reflectivity from Janecek
-  //"REFLECTIVITY SPECTRA FOR COMMONLY USED REFLECTORS"
-  G4double PTFE_Reflectivity[nentries] =
+    //------------------------------------------------------------------------------
+    //teflon properties
+    //------------------------------------------------------------------------------
+
+    //PTFE reflectivity from Janecek
+    //"REFLECTIVITY SPECTRA FOR COMMONLY USED REFLECTORS"
+    G4double PTFE_Reflectivity[nentries] =
     {0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95,
      0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95};
 
-  G4MaterialPropertiesTable* Teflon_mt = new G4MaterialPropertiesTable();
-  Teflon_mt->AddProperty("REFLECTIVITY",HeN_Energy, PTFE_Reflectivity ,nentries);
+    G4MaterialPropertiesTable* Teflon_mt = new G4MaterialPropertiesTable();
+    Teflon_mt->AddProperty("REFLECTIVITY",HeN_Energy, PTFE_Reflectivity ,nentries);
 
-  fNistManager->FindOrBuildMaterial("ATTeflon")->SetMaterialPropertiesTable(Teflon_mt);
-  
-  //------------------------------------------------------------------------------
-  //mylar
-  //------------------------------------------------------------------------------
+    fNistManager->FindOrBuildMaterial("ATTeflon")->SetMaterialPropertiesTable(Teflon_mt);
 
-  //flat 95% according to Seian's thesis
-  G4double mylar_REFL[nentries] = 
+    //------------------------------------------------------------------------------
+    //mylar
+    //------------------------------------------------------------------------------
+
+    //flat 95% according to Seian's thesis
+    G4double mylar_REFL[nentries] =
     {0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95,
      0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95};
 
-  //These seem to be the same as for quartz. In terms of the simulation
-  //these numbers are not very relevant. Interpolated and extrapolated
-  //results of Seian to match my energies and range
-  // G4double mylar_RIND[nentries] =
-  //   {1.51551, 1.5173, 1.51899, 1.52084, 1.52256, 1.52418, 1.52611,
-  //    1.52752, 1.52931, 1.53097, 1.53321, 1.53548, 1.53828, 1.54184,
-  //    1.54528, 1.55176, 1.55819, 1.56375};
+    //These seem to be the same as for quartz. In terms of the simulation
+    //these numbers are not very relevant. Interpolated and extrapolated
+    //results of Seian to match my energies and range
+    // G4double mylar_RIND[nentries] =
+    //   {1.51551, 1.5173, 1.51899, 1.52084, 1.52256, 1.52418, 1.52611,
+    //    1.52752, 1.52931, 1.53097, 1.53321, 1.53548, 1.53828, 1.54184,
+    //    1.54528, 1.55176, 1.55819, 1.56375};
 
-  //http://www.filmetrics.com/refractive-index-database/PET/Estar-Melinex-Mylar
-  G4double mylar_RIND[nentries] =
-    {1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 
+    //http://www.filmetrics.com/refractive-index-database/PET/Estar-Melinex-Mylar
+    G4double mylar_RIND[nentries] =
+    {1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68,
      1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68, 1.68};
 
-  G4MaterialPropertiesTable* Mylar_mt = new G4MaterialPropertiesTable();
-  Mylar_mt->AddProperty("REFLECTIVITY",HeN_Energy, mylar_REFL ,nentries); 
-  Mylar_mt->AddProperty("RINDEX",HeN_Energy,mylar_RIND, nentries);
+    G4MaterialPropertiesTable* Mylar_mt = new G4MaterialPropertiesTable();
+    Mylar_mt->AddProperty("REFLECTIVITY",HeN_Energy, mylar_REFL ,nentries);
+    Mylar_mt->AddProperty("RINDEX",HeN_Energy,mylar_RIND, nentries);
 
-  fNistManager->FindOrBuildMaterial("ATMylarW")->SetMaterialPropertiesTable(Mylar_mt);
+    fNistManager->FindOrBuildMaterial("ATMylarW")->SetMaterialPropertiesTable(Mylar_mt);
 
-  //------------------------------------------------------------------------------
-  //Epoxy (best guesses I could do)
-  //------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------
+    //Epoxy (best guesses I could do)
+    //------------------------------------------------------------------------------
 
-  //the film refractive index at 589 nm from Martin Sharratt's e-mail
-  //no dependency known
-  G4double Epoxy_RIND[nentries] =
+    //the film refractive index at 589 nm from Martin Sharratt's e-mail
+    //no dependency known
+    G4double Epoxy_RIND[nentries] =
     {1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54,
      1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54, 1.54};
 
-  //use 1, the pmt acceptance spectrum already includes the epoxy effect according
-  //to e-mail from Sharratt
-  G4double Epoxy_Transmittance[nentries] = 
-    {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-     1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-  
-  G4MaterialPropertiesTable *Epoxy_mt = new G4MaterialPropertiesTable();
-  Epoxy_mt->AddProperty("RINDEX",HeN_Energy,Epoxy_RIND, nentries);
-  Epoxy_mt->AddProperty("TRANSMITTANCE", HeN_Energy, Epoxy_Transmittance, nentries);
-
-  fNistManager->FindOrBuildMaterial("ATEpoxy")->SetMaterialPropertiesTable(Epoxy_mt);
-
-  //------------------------------------------------------------------------------
-  //Silicon photomultipliers (currently set so that every hit is detected!)
-  //------------------------------------------------------------------------------
-
-  // detect every photon that hits the pmt. This can be used to correlate which
-  // wavelengths are detected more efficiently
-  G4double SiPMT_EFF[nentries] = 
+    //use 1, the pmt acceptance spectrum already includes the epoxy effect according
+    //to e-mail from Sharratt
+    G4double Epoxy_Transmittance[nentries] =
     {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
-  // Photocathod reflectivity, currently 0, so detect all
-  G4double SiPMT_REFL[nentries]   =  
+    G4MaterialPropertiesTable *Epoxy_mt = new G4MaterialPropertiesTable();
+    Epoxy_mt->AddProperty("RINDEX",HeN_Energy,Epoxy_RIND, nentries);
+    Epoxy_mt->AddProperty("TRANSMITTANCE", HeN_Energy, Epoxy_Transmittance, nentries);
+
+    fNistManager->FindOrBuildMaterial("ATEpoxy")->SetMaterialPropertiesTable(Epoxy_mt);
+
+    //------------------------------------------------------------------------------
+    //Silicon photomultipliers (currently set so that every hit is detected!)
+    //------------------------------------------------------------------------------
+
+    // detect every photon that hits the pmt. This can be used to correlate which
+    // wavelengths are detected more efficiently
+    G4double SiPMT_EFF[nentries] =
+    {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+     1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+    // Photocathod reflectivity, currently 0, so detect all
+    G4double SiPMT_REFL[nentries]   =
     {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-  G4MaterialPropertiesTable *SiPMT_mt = new G4MaterialPropertiesTable();
-  SiPMT_mt->AddProperty("EFFICIENCY",HeN_Energy,SiPMT_EFF, nentries);
-  SiPMT_mt->AddProperty("REFLECTIVITY",HeN_Energy,SiPMT_REFL, nentries);
-  
-  fNistManager->FindOrBuildMaterial("ATSiPMT")->SetMaterialPropertiesTable(SiPMT_mt);
+    G4MaterialPropertiesTable *SiPMT_mt = new G4MaterialPropertiesTable();
+    SiPMT_mt->AddProperty("EFFICIENCY",HeN_Energy,SiPMT_EFF, nentries);
+    SiPMT_mt->AddProperty("REFLECTIVITY",HeN_Energy,SiPMT_REFL, nentries);
 
-  //------------------------------------------------------------------------------
-  //Create optical surfaces
-  //------------------------------------------------------------------------------
-  
-  //teflon - only lambertian reflection, relatively OK simple approximation
-  G4OpticalSurface* OptTeflonSurface = 
-    new G4OpticalSurface("OTeflonSurface",  unified, groundfrontpainted, dielectric_dielectric);
+    fNistManager->FindOrBuildMaterial("ATSiPMT")->SetMaterialPropertiesTable(SiPMT_mt);
 
-  //relate the materials table
-  OptTeflonSurface->SetMaterialPropertiesTable(Teflon_mt);
+    //------------------------------------------------------------------------------
+    //Create optical surfaces
+    //------------------------------------------------------------------------------
 
-  //set optical surfaces
-  new G4LogicalSkinSurface("LSTeflonCylSurface",fTeflonCylLogic, OptTeflonSurface);
-  new G4LogicalSkinSurface("LSTeflonEndSurface",fTeflonCylEndLogic, OptTeflonSurface);
+    //teflon - only lambertian reflection, relatively OK simple approximation
+    G4OpticalSurface* OptTeflonSurface =
+            new G4OpticalSurface("OTeflonSurface",  unified, groundfrontpainted, dielectric_dielectric);
 
-  //------------------------------------------------------------------------------------
+    //relate the materials table
+    OptTeflonSurface->SetMaterialPropertiesTable(Teflon_mt);
 
-  //Mylar windows. model uses only reflection and absorption
-  G4OpticalSurface* OptMylarSurface = 
-    new G4OpticalSurface("OMylarSurface",  unified, polishedfrontpainted, dielectric_dielectric);
-  OptMylarSurface->SetMaterialPropertiesTable(Mylar_mt);
+    //set optical surfaces
+    new G4LogicalSkinSurface("LSTeflonCylSurface",fTeflonCylLogic, OptTeflonSurface);
+    new G4LogicalSkinSurface("LSTeflonEndSurface",fTeflonCylEndLogic, OptTeflonSurface);
 
-  new G4LogicalSkinSurface("LSMylarSurface", fMylarLogic, OptMylarSurface);
-  if (fMakeMylarSections) {
-    new G4LogicalSkinSurface("LSMylarSecSurface", fMylarSectionLogic, OptMylarSurface);
-  }
+    //------------------------------------------------------------------------------------
 
- //------------------------------------------------------------------------------------
+    //Mylar windows. model uses only reflection and absorption
+    G4OpticalSurface* OptMylarSurface =
+            new G4OpticalSurface("OMylarSurface",  unified, polishedfrontpainted, dielectric_dielectric);
+    OptMylarSurface->SetMaterialPropertiesTable(Mylar_mt);
 
-  //epoxy surface.  It should reflect, refract or absorb
-  if (fMakeEpoxy) {
-    G4OpticalSurface* OptEpoxySurface = 
-      new G4OpticalSurface("OEpoxySurface",  unified, ground, dielectric_dielectric);
-    //janecek, moses 2010; ground sigmaalpha 12 deg = 0.21rad 
-    OptEpoxySurface->SetSigmaAlpha(0.21);
-    OptEpoxySurface->SetMaterialPropertiesTable(Epoxy_mt);
-    
-    new G4LogicalSkinSurface("LSEpoxySurface", fEpoxyLogic, OptEpoxySurface);
-  }
+    new G4LogicalSkinSurface("LSMylarSurface", fMylarLogic, OptMylarSurface);
+    if (fMakeMylarSections) {
+        new G4LogicalSkinSurface("LSMylarSecSurface", fMylarSectionLogic, OptMylarSurface);
+    }
 
- //------------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------------
 
-  //pmt surface. The specified model uses ONLY reflection or absorption
-  G4OpticalSurface* OptPmtSurface = 
-    new G4OpticalSurface("OPmtSurface",  unified, polishedfrontpainted, dielectric_dielectric);
-  OptPmtSurface->SetMaterialPropertiesTable(SiPMT_mt);
+    //epoxy surface.  It should reflect, refract or absorb
+    if (fMakeEpoxy) {
+        G4OpticalSurface* OptEpoxySurface =
+                new G4OpticalSurface("OEpoxySurface",  unified, ground, dielectric_dielectric);
+        //janecek, moses 2010; ground sigmaalpha 12 deg = 0.21rad
+        OptEpoxySurface->SetSigmaAlpha(0.21);
+        OptEpoxySurface->SetMaterialPropertiesTable(Epoxy_mt);
 
-  new G4LogicalSkinSurface("LSPmtSurfarce", fPMTLogic, OptPmtSurface);
+        new G4LogicalSkinSurface("LSEpoxySurface", fEpoxyLogic, OptEpoxySurface);
+    }
+
+    //------------------------------------------------------------------------------------
+
+    //pmt surface. The specified model uses ONLY reflection or absorption
+    G4OpticalSurface* OptPmtSurface =
+            new G4OpticalSurface("OPmtSurface",  unified, polishedfrontpainted, dielectric_dielectric);
+    OptPmtSurface->SetMaterialPropertiesTable(SiPMT_mt);
+
+    new G4LogicalSkinSurface("LSPmtSurfarce", fPMTLogic, OptPmtSurface);
 
 } //end SetOpticalProperties()
 
 void A2ActiveHe3::SetScintillationYield(G4double scintyield) {
 
-  if (scintyield > 0.01) {
-    fScintYield = scintyield;
-    G4cout << "A2ActiveHe3::SetScintillationYield() Using user-set scintillation yield value " << 
-      fScintYield << " per MeV" << G4endl;
-  }
-  else {
-    G4cout << "A2ActiveHe3::SetScintillationYield() Using default value for fScintYield " << 
-      fScintYield << " per MeV" << G4endl;
-  }
+    if (scintyield > 0.01) {
+        fScintYield = scintyield;
+        G4cout << "A2ActiveHe3::SetScintillationYield() Using user-set scintillation yield value " <<
+                  fScintYield << " per MeV" << G4endl;
+    }
+    else {
+        G4cout << "A2ActiveHe3::SetScintillationYield() Using default value for fScintYield " <<
+                  fScintYield << " per MeV" << G4endl;
+    }
 }
 void A2ActiveHe3::DefineMaterials()
 {
-  G4double density, fractionmass;
-  G4int ncomponents;
-  //G4double pressure, temperature, a, z;
+    G4double density, fractionmass;
+    G4int ncomponents;
+    //G4double pressure, temperature, a, z;
 
-  G4Material* BerylliumW = new G4Material("ATBerylliumW", density = 1.8480*g/cm3, ncomponents = 7);
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(14), 0.06*perCent);      //Si
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(4), 98.73*perCent);      //Be
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(6), 0.15*perCent);       //C
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(8), 0.75*perCent);       //O
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(12), 0.08*perCent);      //Mg
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(13), 0.1*perCent);       //Al
-  BerylliumW->AddElement(fNistManager->FindOrBuildElement(26), 0.13*perCent);      //Fe
+    G4Material* BerylliumW = new G4Material("ATBerylliumW", density = 1.8480*g/cm3, ncomponents = 7);
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(14), 0.06*perCent);      //Si
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(4), 98.73*perCent);      //Be
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(6), 0.15*perCent);       //C
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(8), 0.75*perCent);       //O
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(12), 0.08*perCent);      //Mg
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(13), 0.1*perCent);       //Al
+    BerylliumW->AddElement(fNistManager->FindOrBuildElement(26), 0.13*perCent);      //Fe
 
-  G4Material* MylarW = new G4Material("ATMylarW", density = 1.4000*g/cm3, ncomponents = 3);
-  MylarW->AddElement(fNistManager->FindOrBuildElement(1), 4.2*perCent);           //H
-  MylarW->AddElement(fNistManager->FindOrBuildElement(6), 62.5*perCent);          //C
-  MylarW->AddElement(fNistManager->FindOrBuildElement(8), 33.3*perCent);          //O
+    G4Material* MylarW = new G4Material("ATMylarW", density = 1.4000*g/cm3, ncomponents = 3);
+    MylarW->AddElement(fNistManager->FindOrBuildElement(1), 4.2*perCent);           //H
+    MylarW->AddElement(fNistManager->FindOrBuildElement(6), 62.5*perCent);          //C
+    MylarW->AddElement(fNistManager->FindOrBuildElement(8), 33.3*perCent);          //O
 
-  G4Material* Teflon = new G4Material("ATTeflon", density = 2.2000*g/cm3, ncomponents = 2);
-  Teflon->AddElement(fNistManager->FindOrBuildElement(6), 24*perCent);            //C
-  Teflon->AddElement(fNistManager->FindOrBuildElement(9), 76*perCent);            //F
+    G4Material* Teflon = new G4Material("ATTeflon", density = 2.2000*g/cm3, ncomponents = 2);
+    Teflon->AddElement(fNistManager->FindOrBuildElement(6), 24*perCent);            //C
+    Teflon->AddElement(fNistManager->FindOrBuildElement(9), 76*perCent);            //F
 
 
-  //Gas mixture and He3 management----------------------------------------------------
+    //Gas mixture and He3 management----------------------------------------------------
 
-  //defining He3 according to
-  // http://hypernews.slac.stanford.edu/HyperNews/geant4/get/hadronprocess/731/1.html
-  G4Element* ATHe3 = new G4Element("ATHe3", "ATHe3", ncomponents=1);
-  ATHe3->AddIsotope((G4Isotope*)fNistManager->FindOrBuildElement(2)->GetIsotope(0), //isot. 0 = 3he
-		    100.*perCent);
+    //defining He3 according to
+    // http://hypernews.slac.stanford.edu/HyperNews/geant4/get/hadronprocess/731/1.html
+    G4Element* ATHe3 = new G4Element("ATHe3", "ATHe3", ncomponents=1);
+    ATHe3->AddIsotope((G4Isotope*)fNistManager->FindOrBuildElement(2)->GetIsotope(0), //isot. 0 = 3he
+                      100.*perCent);
 
-  //See HeGasDensity.nb. Might be an idea to include N2 effect to density
-  //G4double he3density = 0.00247621*g/cm3; //20bar, calculated from ideal gas law
-  G4double he3density = 0.0033*g/cm3; //20bar, calculated from ideal gas law
+    //See HeGasDensity.nb. Might be an idea to include N2 effect to density
+    //G4double he3density = 0.00247621*g/cm3; //20bar, calculated from ideal gas law
+    G4double he3density = 0.0033*g/cm3; //20bar, calculated from ideal gas law
 
-  G4Material* GasMix = new G4Material("ATGasMix", he3density, ncomponents = 2);
-  GasMix->AddElement(ATHe3, 99.95*perCent);                                       //He3
-  // GasMix->AddElement(fNistManager->FindOrBuildElement(2), 99.95*perCent);         //He4
-  GasMix->AddElement(fNistManager->FindOrBuildElement(7), 0.05*perCent);           //N
-  //Gas mixture and He3 end-----------------------------------------------------
-  //----! IMPORTANT! Epoxy CURRENTLY TAKEN FROM A2 SIMULATION,------------------
-  //NO IDEA WHETHER IT IS CORRECT OR NOT
+    G4Material* GasMix = new G4Material("ATGasMix", he3density, ncomponents = 2);
+    GasMix->AddElement(ATHe3, 99.95*perCent);                                       //He3
+    // GasMix->AddElement(fNistManager->FindOrBuildElement(2), 99.95*perCent);         //He4
+    GasMix->AddElement(fNistManager->FindOrBuildElement(7), 0.05*perCent);           //N
+    //Gas mixture and He3 end-----------------------------------------------------
+    //----! IMPORTANT! Epoxy CURRENTLY TAKEN FROM A2 SIMULATION,------------------
+    //NO IDEA WHETHER IT IS CORRECT OR NOT
 
-  //Epoxy resin (C21H25Cl05) ***not certain if correct chemical formula or density
-  //for colder temperature***:
-  G4Material* EpoxyResin=new G4Material("EpoxyResin", density=1.15*g/cm3, ncomponents=4);
-  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(6), 21); //carbon
-  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(1), 25); //hydrogen
-  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(17), 1); //chlorine
-  EpoxyResin->AddElement(fNistManager->FindOrBuildElement(8), 5);  //oxygen
+    //Epoxy resin (C21H25Cl05) ***not certain if correct chemical formula or density
+    //for colder temperature***:
+    G4Material* EpoxyResin=new G4Material("EpoxyResin", density=1.15*g/cm3, ncomponents=4);
+    EpoxyResin->AddElement(fNistManager->FindOrBuildElement(6), 21); //carbon
+    EpoxyResin->AddElement(fNistManager->FindOrBuildElement(1), 25); //hydrogen
+    EpoxyResin->AddElement(fNistManager->FindOrBuildElement(17), 1); //chlorine
+    EpoxyResin->AddElement(fNistManager->FindOrBuildElement(8), 5);  //oxygen
 
-  //Amine Hardener (C8H18N2) ***not certain if correct chemical formula or density 
-  //for colder temperature***:
-  G4Material* Epoxy13BAC=new G4Material("Epoxy13BAC", density=0.94*g/cm3, ncomponents=3);
-  Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(6), 8);
-  Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(1), 18);
-  Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(7), 2);
+    //Amine Hardener (C8H18N2) ***not certain if correct chemical formula or density
+    //for colder temperature***:
+    G4Material* Epoxy13BAC=new G4Material("Epoxy13BAC", density=0.94*g/cm3, ncomponents=3);
+    Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(6), 8);
+    Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(1), 18);
+    Epoxy13BAC->AddElement(fNistManager->FindOrBuildElement(7), 2);
 
-  //Epoxy adhesive with mix ratio 100:25 parts by weight resin/hardener
-  // ***don't know density at cold temperature***:
-  G4Material* Epoxy=new G4Material("ATEpoxy", density=1.2*g/cm3, ncomponents=2);
-  Epoxy->AddMaterial(EpoxyResin, fractionmass=0.8);
-  Epoxy->AddMaterial(Epoxy13BAC, fractionmass=0.2);
-  //-----------------------------------------------------------------------------
+    //Epoxy adhesive with mix ratio 100:25 parts by weight resin/hardener
+    // ***don't know density at cold temperature***:
+    G4Material* Epoxy=new G4Material("ATEpoxy", density=1.2*g/cm3, ncomponents=2);
+    Epoxy->AddMaterial(EpoxyResin, fractionmass=0.8);
+    Epoxy->AddMaterial(Epoxy13BAC, fractionmass=0.2);
+    //-----------------------------------------------------------------------------
 
-  //just silicon for now
-  G4Material* SiPMT = new G4Material("ATSiPMT", density = 2.329*g/cm3, ncomponents = 1);
-  SiPMT->AddElement(fNistManager->FindOrBuildElement(14),100.*perCent);    //Si
+    //just silicon for now
+    G4Material* SiPMT = new G4Material("ATSiPMT", density = 2.329*g/cm3, ncomponents = 1);
+    SiPMT->AddElement(fNistManager->FindOrBuildElement(14),100.*perCent);    //Si
 
 }
 
 //---------------------------------------------------------------------------
 void A2ActiveHe3::ReadParameters(const char* file)
 {
-  //
-  // Initialise detector parameters from file
-  //
-  char* keylist[] = { (char *)"AT-Dim:", (char *)"AT-WLS:", 
-		      (char *)"AT-Scint:", (char *)"Run-Mode:", NULL };
-  enum { EAT_Dim, EAT_WLS, EAT_Scint, ERun_Mode, ENULL };
-  G4int ikey, iread;
-  G4int ierr = 0;
-  char line[256];
-  char delim[64];
-  //char hname[32];
-  //char fname[32];
-  //G4double x,y,z,dx,dy,dz;
-  FILE* pdata;
-  if( (pdata = fopen(file,"r")) == NULL ){
-    printf("Error opening detector parameter file: %s\n",file);
-    return;
-  }
-  while( fgets(line,256,pdata) ){
-    if( line[0] == '#' ) continue;       // comment #
-    printf("%s\n",line);                 // record datum to log
-    sscanf(line,"%s",delim);
-    for(ikey=0; ikey<ENULL; ikey++)
-      if(!strcmp(keylist[ikey],delim)) break;
-    switch( ikey ){
-    default:
-      printf("Unrecognised delimiter: %s\n",delim);
-      ierr++;
-      break;
-    case EAT_Dim:
-      iread = sscanf(line,"%*s%lf%lf%lf%lf%lf%lf%lf",
-		     &fHeContainerZ,&fHeContainerR,&fContainerThickness,
-		     &fExtensionZU,&fExtensionZD,&fExtensionR,&fBeThickness);
-      if( iread != 7 ) ierr++;
-      break;
-    case EAT_WLS:
-      iread = sscanf(line,"%*s%d%lf%lf%lf",
-		     &fNwls,&fWLSthick,&fRadClr,&fLatClr);
-      if( iread != 4 ) ierr++;
-      break;
-    case EAT_Scint:
-      iread =sscanf(line,"%*s%lf",
-		    &fScintYield);
-      if( iread != 1 ) ierr++;
-      break;
-    case ERun_Mode:
-      iread = sscanf(line,"%*s%d%d%d%d",
-		     &fIsOverlapVol,&fIsWLS,&fOpticalSimulation,&fMakeMylarSections);
-      if( iread != 4 ) ierr++;
-      break;
+    //
+    // Initialise detector parameters from file
+    //
+    char* keylist[] = { (char *)"AT-Dim:", (char *)"AT-WLS:",
+                        (char *)"AT-Scint:", (char *)"Run-Mode:", NULL };
+    enum { EAT_Dim, EAT_WLS, EAT_Scint, ERun_Mode, ENULL };
+    G4int ikey, iread;
+    G4int ierr = 0;
+    char line[256];
+    char delim[64];
+    //char hname[32];
+    //char fname[32];
+    //G4double x,y,z,dx,dy,dz;
+    FILE* pdata;
+    if( (pdata = fopen(file,"r")) == NULL ){
+        printf("Error opening detector parameter file: %s\n",file);
+        return;
     }
-    if( ierr ){
-      printf("Fatal Error: invalid read of parameter line %s\n %s\n",
-	     keylist[ikey],line);
-      exit(-1);
+    while( fgets(line,256,pdata) ){
+        if( line[0] == '#' ) continue;       // comment #
+        printf("%s\n",line);                 // record datum to log
+        sscanf(line,"%s",delim);
+        for(ikey=0; ikey<ENULL; ikey++)
+            if(!strcmp(keylist[ikey],delim)) break;
+        switch( ikey ){
+        default:
+            printf("Unrecognised delimiter: %s\n",delim);
+            ierr++;
+            break;
+        case EAT_Dim:
+            iread = sscanf(line,"%*s%lf%lf%lf%lf%lf%lf%lf",
+                           &fHeContainerZ,&fHeContainerR,&fContainerThickness,
+                           &fExtensionZU,&fExtensionZD,&fExtensionR,&fBeThickness);
+            if( iread != 7 ) ierr++;
+            break;
+        case EAT_WLS:
+            iread = sscanf(line,"%*s%d%lf%lf%lf",
+                           &fNwls,&fWLSthick,&fRadClr,&fLatClr);
+            if( iread != 4 ) ierr++;
+            break;
+        case EAT_Scint:
+            iread =sscanf(line,"%*s%lf",
+                          &fScintYield);
+            if( iread != 1 ) ierr++;
+            break;
+        case ERun_Mode:
+            iread = sscanf(line,"%*s%d%d%d%d",
+                           &fIsOverlapVol,&fIsWLS,&fOpticalSimulation,&fMakeMylarSections);
+            if( iread != 4 ) ierr++;
+            break;
+        }
+        if( ierr ){
+            printf("Fatal Error: invalid read of parameter line %s\n %s\n",
+                   keylist[ikey],line);
+            exit(-1);
+        }
     }
-  }
 }
 
 
 /**********************************************************
 
-This function builds the sensitive detector and places
-it to HeOutsideTeflonLogic 
+This function builds the sensitive detector
 
 **********************************************************/
 
-//NEW
 void A2ActiveHe3::MakeSensitiveDetector(){
-        if(!fAHe3SD){
+    if(!fAHe3SD){
         G4SDManager* SDman = G4SDManager::GetSDMpointer();
-        fAHe3SD = new A2SD("AHe3SD",1); //not sure what Nelements should actually be
-        //right now I have one, since I believe it is just the one volume that scintillates
+        fAHe3SD = new A2SD("AHe3SD",fNwls);
         SDman->AddNewDetector(fAHe3SD);
-        fHeOutsideTeflonLogic->SetSensitiveDetector(fAHe3SD); //John Annand's code implies this is the volume that should be set as a sensitive detector
-        fRegionAHe3->AddRootLogicalVolume(fHeOutsideTeflonLogic);
-        }
+        fWLSLogic->SetSensitiveDetector(fAHe3SD);
+        fRegionAHe3->AddRootLogicalVolume(fWLSLogic);
+    }
 }
 

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -267,12 +267,20 @@ void A2ActiveHe3::MakeVessel() {
              fNistManager->FindOrBuildMaterial("G4_Be"), //material
              "LogicBerylliumWindow");
 
-    fHeOutsideTeflonLogic = new G4LogicalVolume
-            (HeOutsideTeflon,
-             fNistManager->FindOrBuildMaterial("ATGasMix"),
-             "LogicHeOutsideTeflon"
-             );
-
+    if(fIsWLS)
+    {
+        fHeOutsideTeflonLogic = new G4LogicalVolume
+                (HeOutsideTeflon,
+                 fNistManager->FindOrBuildMaterial("ATGasPure"),
+                 "LogicHeOutsideTeflon");
+    }
+    else
+    {
+        fHeOutsideTeflonLogic = new G4LogicalVolume
+                (HeOutsideTeflon,
+                 fNistManager->FindOrBuildMaterial("ATGasMix"),
+                 "LogicHeOutsideTeflon");
+    }
     //------------------------------------------------------------------------------
     //Set visual attributes
     //------------------------------------------------------------------------------
@@ -282,16 +290,16 @@ void A2ActiveHe3::MakeVessel() {
     G4VisAttributes* cyan   = new G4VisAttributes( G4Colour(0.0,1.0,1.0)  );
 
     fVesselLogic->SetVisAttributes(G4VisAttributes::Invisible);
-    LMainCell->SetVisAttributes(grey);
-    //LMainCell->SetVisAttributes(G4VisAttributes::Invisible);
-    LExtCellU->SetVisAttributes(grey);
-    //LExtCellU->SetVisAttributes(G4VisAttributes::Invisible);
-    LExtCellD->SetVisAttributes(grey);
-    //LExtCellD->SetVisAttributes(G4VisAttributes::Invisible);
-    LMainCellEnd->SetVisAttributes(grey);
-    //LMainCellEnd->SetVisAttributes(G4VisAttributes::Invisible);
-    LBerylliumWindow->SetVisAttributes(lblue);
-    //LBerylliumWindow->SetVisAttributes(G4VisAttributes::Invisible);
+    //LMainCell->SetVisAttributes(grey);
+    LMainCell->SetVisAttributes(G4VisAttributes::Invisible);
+    //LExtCellU->SetVisAttributes(grey);
+    LExtCellU->SetVisAttributes(G4VisAttributes::Invisible);
+    //LExtCellD->SetVisAttributes(grey);
+    LExtCellD->SetVisAttributes(G4VisAttributes::Invisible);
+    //LMainCellEnd->SetVisAttributes(grey);
+    LMainCellEnd->SetVisAttributes(G4VisAttributes::Invisible);
+    //LBerylliumWindow->SetVisAttributes(lblue);
+    LBerylliumWindow->SetVisAttributes(G4VisAttributes::Invisible);
     fHeOutsideTeflonLogic->SetVisAttributes(cyan);
     //fHeOutsideTeflonLogic->SetVisAttributes(G4VisAttributes::Invisible);
 
@@ -383,9 +391,8 @@ void A2ActiveHe3::MakeWLS()
     G4double d0 = r0*sin(th/2) - 0.001*mm; // slightly smaller so plates dont touch
     G4double d1 = d0 - fWLSthick*tan(th/2);
     G4Trd* wls = new G4Trd("WLS-bar", z0,z0,d0,d1,fWLSthick/2);
-    fWLSLogic = new G4LogicalVolume
-            (wls,fNistManager->FindOrBuildMaterial("G4_PLASTIC_SC_VINYLTOLUENE"),
-             "LogicWLS");
+    //fWLSLogic = new G4LogicalVolume(wls, fNistManager->FindOrBuildMaterial("G4_PLASTIC_SC_VINYLTOLUENE"), "LogicWLS");
+    fWLSLogic = new G4LogicalVolume(wls, fNistManager->FindOrBuildMaterial("PMMA"), "LogicWLS");
     G4VisAttributes* blue   = new G4VisAttributes( G4Colour(0.0,0.0,1.0)  );
     fWLSLogic->SetVisAttributes(blue);
 }
@@ -1022,6 +1029,53 @@ void A2ActiveHe3::SetOpticalProperties() {
 
     //add these properties to GasMix
     fNistManager->FindOrBuildMaterial("ATGasMix")->SetMaterialPropertiesTable(HeN_mt);
+    fNistManager->FindOrBuildMaterial("ATGasPure")->SetMaterialPropertiesTable(HeN_mt);
+
+    G4double photonEnergy[] =
+    {2.00*eV,2.03*eV,2.06*eV,2.09*eV,2.12*eV,2.15*eV,2.18*eV,2.21*eV,2.24*eV,2.27*eV,
+     2.30*eV,2.33*eV,2.36*eV,2.39*eV,2.42*eV,2.45*eV,2.48*eV,2.51*eV,2.54*eV,2.57*eV,
+     2.60*eV,2.63*eV,2.66*eV,2.69*eV,2.72*eV,2.75*eV,2.78*eV,2.81*eV,2.84*eV,2.87*eV,
+     2.90*eV,2.93*eV,2.96*eV,2.99*eV,3.02*eV,3.05*eV,3.08*eV,3.11*eV,3.14*eV,3.17*eV,
+     3.20*eV,3.23*eV,3.26*eV,3.29*eV,3.32*eV,3.35*eV,3.38*eV,3.41*eV,3.44*eV,3.47*eV};
+
+    const G4int nEntries = sizeof(photonEnergy)/sizeof(G4double);
+
+    G4double refractiveIndexWLSfiber[] =
+    { 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+      1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+      1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+      1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60,
+      1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60, 1.60};
+
+    assert(sizeof(refractiveIndexWLSfiber) == sizeof(photonEnergy));
+
+    G4double absWLSfiber[] =
+    {5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,
+     5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,
+     5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,5.40*m,1.10*m,
+     1.10*m,1.10*m,1.10*m,1.10*m,1.10*m,1.10*m, 1.*mm, 1.*mm, 1.*mm, 1.*mm,
+      1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm, 1.*mm};
+
+    assert(sizeof(absWLSfiber) == sizeof(photonEnergy));
+
+    G4double emissionFib[] =
+    {0.05, 0.10, 0.30, 0.50, 0.75, 1.00, 1.50, 1.85, 2.30, 2.75,
+     3.25, 3.80, 4.50, 5.20, 6.00, 7.00, 8.50, 9.50, 11.1, 12.4,
+     12.9, 13.0, 12.8, 12.3, 11.1, 11.0, 12.0, 11.0, 17.0, 16.9,
+     15.0, 9.00, 2.50, 1.00, 0.05, 0.00, 0.00, 0.00, 0.00, 0.00,
+     0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00};
+
+    assert(sizeof(emissionFib) == sizeof(photonEnergy));
+
+    // Add entries into properties table
+    G4MaterialPropertiesTable* WLS_mt = new G4MaterialPropertiesTable();
+    WLS_mt->AddProperty("RINDEX",photonEnergy,refractiveIndexWLSfiber,nEntries);
+    WLS_mt->AddProperty("ABSLENGTH",photonEnergy,absWLSfiber,nEntries);
+    //WLS_mt->AddProperty("WLSABSLENGTH",photonEnergy,absWLSfiber,nEntries);
+    WLS_mt->AddProperty("WLSCOMPONENT",photonEnergy,emissionFib,nEntries);
+    WLS_mt->AddConstProperty("WLSTIMECONSTANT", 0.5*ns);
+
+    fNistManager->FindOrBuildMaterial("PMMA")->SetMaterialPropertiesTable(WLS_mt);
 
     //------------------------------------------------------------------------------
     //teflon properties
@@ -1113,6 +1167,17 @@ void A2ActiveHe3::SetOpticalProperties() {
     //Create optical surfaces
     //------------------------------------------------------------------------------
 
+    //WLS surface.  It should reflect, refract or absorb
+    if (fIsWLS) {
+        G4OpticalSurface* OptWLSSurface =
+                new G4OpticalSurface("OWLSSurface",  unified, ground, dielectric_dielectric);
+        OptWLSSurface->SetMaterialPropertiesTable(WLS_mt);
+
+        new G4LogicalSkinSurface("LSWLSSurface", fWLSLogic, OptWLSSurface);
+    }
+
+    //------------------------------------------------------------------------------------
+
     //teflon - only lambertian reflection, relatively OK simple approximation
     G4OpticalSurface* OptTeflonSurface =
             new G4OpticalSurface("OTeflonSurface",  unified, groundfrontpainted, dielectric_dielectric);
@@ -1196,6 +1261,14 @@ void A2ActiveHe3::DefineMaterials()
     Teflon->AddElement(fNistManager->FindOrBuildElement(6), 24*perCent);            //C
     Teflon->AddElement(fNistManager->FindOrBuildElement(9), 76*perCent);            //F
 
+    //--------------------------------------------------
+    // WLSfiber PMMA
+    //--------------------------------------------------
+
+    G4Material* PMMA = new G4Material("PMMA", density = 1.190*g/cm3, ncomponents = 3);
+    PMMA->AddElement(fNistManager->FindOrBuildElement(6), 5); //C
+    PMMA->AddElement(fNistManager->FindOrBuildElement(1), 8); //H
+    PMMA->AddElement(fNistManager->FindOrBuildElement(8), 2); //O
 
     //Gas mixture and He3 management----------------------------------------------------
 
@@ -1216,6 +1289,9 @@ void A2ActiveHe3::DefineMaterials()
     //Gas mixture and He3 end-----------------------------------------------------
     //----! IMPORTANT! Epoxy CURRENTLY TAKEN FROM A2 SIMULATION,------------------
     //NO IDEA WHETHER IT IS CORRECT OR NOT
+
+    G4Material* GasPure = new G4Material("ATGasPure", he3density, ncomponents = 1);
+    GasPure->AddElement(ATHe3, 100.*perCent);                                       //He3
 
     //Epoxy resin (C21H25Cl05) ***not certain if correct chemical formula or density
     //for colder temperature***:

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -24,6 +24,7 @@
 #include "G4PhysicalConstants.hh"
 
 #include "A2SD.hh" //NEW
+#include "A2VisSD.hh" //NEW
 
 //constructor
 A2ActiveHe3::A2ActiveHe3() {
@@ -51,8 +52,10 @@ A2ActiveHe3::A2ActiveHe3() {
   fPMTPhysic = NULL;
   fEpoxyPhysic = NULL;
 
-  fAHe3SD=NULL; //NEW
-  
+  fRegionAHe3 = new G4Region("AHe3");
+  fAHe3SD = NULL; //NEW
+  fAHe3VisSD = NULL; //NEW
+
   //initiate nist manager
   fNistManager=G4NistManager::Instance();
 
@@ -74,7 +77,9 @@ A2ActiveHe3::A2ActiveHe3() {
 //destructor
 A2ActiveHe3::~A2ActiveHe3() {
   //delete Rot;
+  if(fRegionAHe3) delete fRegionAHe3; //remove the sensitive detector
   if(fAHe3SD) delete fAHe3SD; //remove the sensitive detector
+  if(fAHe3VisSD) delete fAHe3VisSD; //remove the sensitive detector
 }
 
 /**********************************************************
@@ -1316,8 +1321,9 @@ void A2ActiveHe3::MakeSensitiveDetector(){
         G4SDManager* SDman = G4SDManager::GetSDMpointer();
         fAHe3SD = new A2SD("AHe3SD",1); //not sure what Nelements should actually be
         //right now I have one, since I believe it is just the one volume that scintillates
-        fHeOutsideTeflonLogic->SetSensitiveDetector(fAHe3SD); //John Annand's code implies this is the volume that should be set as a sensitive detector
         SDman->AddNewDetector(fAHe3SD);
+        fHeOutsideTeflonLogic->SetSensitiveDetector(fAHe3SD); //John Annand's code implies this is the volume that should be set as a sensitive detector
+        fRegionAHe3->AddRootLogicalVolume(fHeOutsideTeflonLogic);
         }
 }
 

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -1171,7 +1171,7 @@ void A2ActiveHe3::DefineMaterials()
 {
   G4double density, fractionmass;
   G4int ncomponents;
-  G4double pressure, temperature, a, z;
+  //G4double pressure, temperature, a, z;
 
   G4Material* BerylliumW = new G4Material("ATBerylliumW", density = 1.8480*g/cm3, ncomponents = 7);
   BerylliumW->AddElement(fNistManager->FindOrBuildElement(14), 0.06*perCent);      //Si
@@ -1253,9 +1253,9 @@ void A2ActiveHe3::ReadParameters(const char* file)
   G4int ierr = 0;
   char line[256];
   char delim[64];
-  char hname[32];
-  char fname[32];
-  G4double x,y,z,dx,dy,dz;
+  //char hname[32];
+  //char fname[32];
+  //G4double x,y,z,dx,dy,dz;
   FILE* pdata;
   if( (pdata = fopen(file,"r")) == NULL ){
     printf("Error opening detector parameter file: %s\n",file);

--- a/src/A2ActiveHe3.cc
+++ b/src/A2ActiveHe3.cc
@@ -1070,8 +1070,8 @@ void A2ActiveHe3::SetOpticalProperties() {
     // Add entries into properties table
     G4MaterialPropertiesTable* WLS_mt = new G4MaterialPropertiesTable();
     WLS_mt->AddProperty("RINDEX",photonEnergy,refractiveIndexWLSfiber,nEntries);
-    WLS_mt->AddProperty("ABSLENGTH",photonEnergy,absWLSfiber,nEntries);
-    //WLS_mt->AddProperty("WLSABSLENGTH",photonEnergy,absWLSfiber,nEntries);
+    //WLS_mt->AddProperty("ABSLENGTH",photonEnergy,absWLSfiber,nEntries);
+    WLS_mt->AddProperty("WLSABSLENGTH",photonEnergy,absWLSfiber,nEntries);
     WLS_mt->AddProperty("WLSCOMPONENT",photonEnergy,emissionFib,nEntries);
     WLS_mt->AddConstProperty("WLSTIMECONSTANT", 0.5*ns);
 
@@ -1170,7 +1170,7 @@ void A2ActiveHe3::SetOpticalProperties() {
     //WLS surface.  It should reflect, refract or absorb
     if (fIsWLS) {
         G4OpticalSurface* OptWLSSurface =
-                new G4OpticalSurface("OWLSSurface",  unified, ground, dielectric_dielectric);
+                new G4OpticalSurface("OWLSSurface",  unified, polished, dielectric_dielectric);
         OptWLSSurface->SetMaterialPropertiesTable(WLS_mt);
 
         new G4LogicalSkinSurface("LSWLSSurface", fWLSLogic, OptWLSSurface);

--- a/src/A2CBOutput.cc
+++ b/src/A2CBOutput.cc
@@ -130,6 +130,14 @@ void A2CBOutput::SetBranches(){
     fTree->Branch("tofy",ftofy,"ftofy[fntof]/F",basket);
     fTree->Branch("tofz",ftofz,"ftofz[fntof]/F",basket);
   }
+  //NEW
+  //Active He3 target stuff
+  //if(A2Target=="ActiveHe3"){
+    fTree->Branch("he3n",&fhe3n,"fhe3n/I",basket);
+    fTree->Branch("he3i",fhe3i,"fhe3i[fhe3n]/I",basket);
+    fTree->Branch("he3e",fhe3e,"fhe3e[fhe3n]/F",basket);
+    fTree->Branch("he3t",fhe3t,"fhe3t[fhe3n]/F",basket);
+  //}
   fTree->Branch("npiz",&fnpiz,"fnpiz/I",basket);
   fTree->Branch("ipiz",fipiz,"fipiz[fnpiz]/I",basket);
   fTree->Branch("epiz",fepiz,"fepiz[fnpiz]/F",basket);
@@ -141,7 +149,7 @@ void A2CBOutput::WriteHit(G4HCofThisEvent* HitsColl){
   G4int CollSize=HitsColl->GetNumberOfCollections();
   //G4cout<<"Collection size "<<CollSize<<" "<<HitsColl->GetHC(0)->GetName()<<" "<<HitsColl->GetHC(1)->GetName()<<G4endl;
   //G4cout<<"Collection size "<<CollSize<<G4endl;
-  fnhits=fntaps=fnvtaps=fvhits=fntof=fnpiz=fnmwpc=0;
+  fnhits=fntaps=fnvtaps=fvhits=fntof=fnpiz=fnmwpc=fhe3n=0;
   fetot=0;
   G4int hci=0;
   for(G4int i=0;i<CollSize;i++){
@@ -225,6 +233,20 @@ void A2CBOutput::WriteHit(G4HCofThisEvent* HitsColl){
 	fepiz[ii]=hit->GetEdep()/GeV;
 	ftpiz[ii]=hit->GetTime()/ns;
 	fipiz[ii]=hit->GetID();
+      }
+    }
+    //NEW
+    //Assume the detector can identify time and energy of each hit
+    if(hc->GetName()=="A2SDHitsAHe3SD"){
+      fhe3n=hc_nhits;
+      for(Int_t ii=0;ii<fhe3n;ii++){
+	A2Hit* hit=static_cast<A2Hit*>(hc->GetHit(ii));
+	fhe3e[ii]=hit->GetEdep()/GeV;
+	fhe3t[ii]=hit->GetTime()/ns;
+	//fhe3x[ii]=hit->GetPos().x()/cm;
+	//fhe3y[ii]=hit->GetPos().y()/cm;
+	//fhe3z[ii]=hit->GetPos().z()/cm;
+	fhe3i[ii]=hit->GetID();
       }
     }
   }

--- a/src/A2CBOutput.cc
+++ b/src/A2CBOutput.cc
@@ -54,6 +54,10 @@ A2CBOutput::A2CBOutput(){
     ftofz=new Float_t[fToFTot];
   }
 
+  fhe3i = new Int_t[10]; //hit index ????
+  fhe3e = new Float_t[10]; //hit energy deposits
+  fhe3t = new Float_t[10]; //hit time
+
   fIsGiBUU = false;
   if (fPGA->GetFileGen())
     fIsGiBUU = (fPGA->GetFileGen()->GetType() == A2FileGenerator::kGiBUU);

--- a/src/A2CBOutput.cc
+++ b/src/A2CBOutput.cc
@@ -54,10 +54,6 @@ A2CBOutput::A2CBOutput(){
     ftofz=new Float_t[fToFTot];
   }
 
-  fhe3i = new Int_t[10]; //hit index ????
-  fhe3e = new Float_t[10]; //hit energy deposits
-  fhe3t = new Float_t[10]; //hit time
-
   fIsGiBUU = false;
   if (fPGA->GetFileGen())
     fIsGiBUU = (fPGA->GetFileGen()->GetType() == A2FileGenerator::kGiBUU);
@@ -137,10 +133,10 @@ void A2CBOutput::SetBranches(){
   //NEW
   //Active He3 target stuff
   //if(A2Target=="ActiveHe3"){
-    fTree->Branch("he3n",&fhe3n,"fhe3n/I",basket);
-    fTree->Branch("he3i",fhe3i,"fhe3i[fhe3n]/I",basket);
-    fTree->Branch("he3e",fhe3e,"fhe3e[fhe3n]/F",basket);
-    fTree->Branch("he3t",fhe3t,"fhe3t[fhe3n]/F",basket);
+    fTree->Branch("nhe3",&fnhe3,"fnhe3/I",basket);
+    fTree->Branch("ihe3",fihe3,"fihe3[fnhe3]/I",basket);
+    fTree->Branch("ehe3",fehe3,"fehe3[fnhe3]/F",basket);
+    fTree->Branch("the3",fthe3,"fthe3[fnhe3]/F",basket);
   //}
   fTree->Branch("npiz",&fnpiz,"fnpiz/I",basket);
   fTree->Branch("ipiz",fipiz,"fipiz[fnpiz]/I",basket);
@@ -153,7 +149,7 @@ void A2CBOutput::WriteHit(G4HCofThisEvent* HitsColl){
   G4int CollSize=HitsColl->GetNumberOfCollections();
   //G4cout<<"Collection size "<<CollSize<<" "<<HitsColl->GetHC(0)->GetName()<<" "<<HitsColl->GetHC(1)->GetName()<<G4endl;
   //G4cout<<"Collection size "<<CollSize<<G4endl;
-  fnhits=fntaps=fnvtaps=fvhits=fntof=fnpiz=fnmwpc=fhe3n=0;
+  fnhits=fntaps=fnvtaps=fvhits=fntof=fnpiz=fnmwpc=fnhe3=0;
   fetot=0;
   G4int hci=0;
   for(G4int i=0;i<CollSize;i++){
@@ -239,18 +235,16 @@ void A2CBOutput::WriteHit(G4HCofThisEvent* HitsColl){
 	fipiz[ii]=hit->GetID();
       }
     }
-    //NEW
-    //Assume the detector can identify time and energy of each hit
     if(hc->GetName()=="A2SDHitsAHe3SD"){
-      fhe3n=hc_nhits;
-      for(Int_t ii=0;ii<fhe3n;ii++){
+      fnhe3=hc_nhits;
+      for(Int_t ii=0;ii<fnhe3;ii++){
 	A2Hit* hit=static_cast<A2Hit*>(hc->GetHit(ii));
-	fhe3e[ii]=hit->GetEdep()/GeV;
-	fhe3t[ii]=hit->GetTime()/ns;
+    fehe3[ii]=hit->GetEdep()/GeV;
+    fthe3[ii]=hit->GetTime()/ns;
 	//fhe3x[ii]=hit->GetPos().x()/cm;
 	//fhe3y[ii]=hit->GetPos().y()/cm;
 	//fhe3z[ii]=hit->GetPos().z()/cm;
-	fhe3i[ii]=hit->GetID();
+    fihe3[ii]=hit->GetID();
       }
     }
   }

--- a/src/A2DetectorConstruction.cc
+++ b/src/A2DetectorConstruction.cc
@@ -26,6 +26,7 @@
 #include "A2SolidTarget.hh"
 #include "A2SolidTargetGeneric.hh"
 #include "A2PolarizedTarget.hh"
+#include "A2ActiveHe3.hh"
 #include "A2DetPID.hh"
 #include "A2DetPID3.hh"
 
@@ -223,6 +224,7 @@ G4VPhysicalVolume* A2DetectorConstruction::Construct()
     else if(fUseTarget=="Solid_Generic") fTarget=static_cast<A2Target*>(new A2SolidTargetGeneric());
     else if(fUseTarget=="Solid_Oct_18") fTarget=static_cast<A2Target*>(new A2SolidTargetGeneric(A2SolidTargetGeneric::kOct_18));
     else if(fUseTarget=="Polarized") fTarget=static_cast<A2Target*>(new A2PolarizedTarget());
+    else if(fUseTarget=="ActiveHe3") fTarget=static_cast<A2Target*>(new A2ActiveHe3());
     else{G4cerr<<"A2DetectorConstruction::Construct() Target type does not exist. See DetectorSetup.mac or README"<<G4endl;exit(1);}
     fTarget->SetMaterial(fTargetMaterial);
     if (fTargetLength)

--- a/src/A2PrimaryGeneratorAction.cc
+++ b/src/A2PrimaryGeneratorAction.cc
@@ -32,8 +32,8 @@ A2PrimaryGeneratorAction::A2PrimaryGeneratorAction()
   //default phase space limits
   fTmin=0;
   fTmax=400*MeV;
-  fThetamin=0;
-  fThetamax=180*deg;
+  fThetaMin=0;
+  fThetaMax=180*deg;
   fBeamEnergy=0;
   fBeamXSigma=0.5*cm;
   fBeamYSigma=0.5*cm;
@@ -267,7 +267,7 @@ void A2PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 void A2PrimaryGeneratorAction::PhaseSpaceGenerator(G4Event* anEvent){
   if(fGenPartType[0]==-1){fGenPartType[0]= PDGtoG3(fParticleGun->GetParticleDefinition()->GetPDGEncoding());G4cout<<"P type "<<fGenPartType[0]<<G4endl;}
   //4-momenta
-  G4float theta=acos((cos(fThetamax)-cos(fThetamin))*G4UniformRand()+cos(fThetamin));
+  G4float theta=acos((cos(fThetaMax)-cos(fThetaMin))*G4UniformRand()+cos(fThetaMin));
   G4float phi=2*3.141592653589*G4UniformRand();
   G4float T=fTmin+(fTmax-fTmin)*G4UniformRand();
   G4float Mass=fParticleGun->GetParticleDefinition()->GetPDGMass();
@@ -320,7 +320,7 @@ void A2PrimaryGeneratorAction::OverlapGenerator(G4Event* anEvent){
   fGenPosition[0]=p3.x()/cm;
   fGenPosition[1]=p3.y()/cm;
   fGenPosition[2]=p3.z()/cm;
-  G4float theta=acos((cos(fThetamax)-cos(fThetamin))*G4UniformRand()+cos(fThetamin));
+  G4float theta=acos((cos(fThetaMax)-cos(fThetaMin))*G4UniformRand()+cos(fThetaMin));
   G4float phi=2*3.141592653589*G4UniformRand();
   G4float T=fTmin+(fTmax-fTmin)*G4UniformRand();
   G4float Mass=fParticleGun->GetParticleDefinition()->GetPDGMass();

--- a/src/A2PrimaryGeneratorAction.cc
+++ b/src/A2PrimaryGeneratorAction.cc
@@ -34,6 +34,8 @@ A2PrimaryGeneratorAction::A2PrimaryGeneratorAction()
   fTmax=400*MeV;
   fThetaMin=0;
   fThetaMax=180*deg;
+  fPhiMin=-180*deg;
+  fPhiMax=180*deg;
   fBeamEnergy=0;
   fBeamXSigma=0.5*cm;
   fBeamYSigma=0.5*cm;
@@ -268,7 +270,7 @@ void A2PrimaryGeneratorAction::PhaseSpaceGenerator(G4Event* anEvent){
   if(fGenPartType[0]==-1){fGenPartType[0]= PDGtoG3(fParticleGun->GetParticleDefinition()->GetPDGEncoding());G4cout<<"P type "<<fGenPartType[0]<<G4endl;}
   //4-momenta
   G4float theta=acos((cos(fThetaMax)-cos(fThetaMin))*G4UniformRand()+cos(fThetaMin));
-  G4float phi=2*3.141592653589*G4UniformRand();
+  G4float phi=fPhiMin+(fPhiMax-fPhiMin)*G4UniformRand();
   G4float T=fTmin+(fTmax-fTmin)*G4UniformRand();
   G4float Mass=fParticleGun->GetParticleDefinition()->GetPDGMass();
   G4float E=T+Mass;
@@ -321,7 +323,7 @@ void A2PrimaryGeneratorAction::OverlapGenerator(G4Event* anEvent){
   fGenPosition[1]=p3.y()/cm;
   fGenPosition[2]=p3.z()/cm;
   G4float theta=acos((cos(fThetaMax)-cos(fThetaMin))*G4UniformRand()+cos(fThetaMin));
-  G4float phi=2*3.141592653589*G4UniformRand();
+  G4float phi=fPhiMin+(fPhiMax-fPhiMin)*G4UniformRand();
   G4float T=fTmin+(fTmax-fTmin)*G4UniformRand();
   G4float Mass=fParticleGun->GetParticleDefinition()->GetPDGMass();
   G4float E=T+Mass;

--- a/src/A2PrimaryGeneratorMessenger.cc
+++ b/src/A2PrimaryGeneratorMessenger.cc
@@ -71,6 +71,18 @@ A2PrimaryGeneratorMessenger::A2PrimaryGeneratorMessenger(
   SetThetaMaxCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   SetThetaMaxCmd->SetUnitCategory("Angle");
 
+  SetPhiMinCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetPhiMin",this);
+  SetPhiMinCmd->SetGuidance("Set the minimum particle phi for the phase space generator");
+  SetPhiMinCmd->SetParameterName("PhiMin",false);
+  SetPhiMinCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  SetPhiMinCmd->SetUnitCategory("Angle");
+
+  SetPhiMaxCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetPhiMax",this);
+  SetPhiMaxCmd->SetGuidance("Set the maximum particle phi for the phase space generator");
+  SetPhiMaxCmd->SetParameterName("PhiMax",false);
+  SetPhiMaxCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  SetPhiMaxCmd->SetUnitCategory("Angle");
+
   SetBeamEnergyCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetBeamEnergy",this);
   SetBeamEnergyCmd->SetGuidance("Set the energy of the photon beam");
   SetBeamEnergyCmd->SetParameterName("BeamEnergy",false);
@@ -134,6 +146,8 @@ A2PrimaryGeneratorMessenger::~A2PrimaryGeneratorMessenger()
   delete SetTmaxCmd;
   delete SetThetaMinCmd;
   delete SetThetaMaxCmd;
+  delete SetPhiMinCmd;
+  delete SetPhiMaxCmd;
   delete SetModeCmd;
   delete SetSeedCmd;
   delete SetBeamEnergyCmd;
@@ -180,6 +194,12 @@ void A2PrimaryGeneratorMessenger::SetNewValue(
   
   if( command == SetThetaMaxCmd )
      { A2Action->SetThetaMax(SetThetaMaxCmd->GetNewDoubleValue(newValue));}
+ 
+  if( command == SetPhiMinCmd )
+     { A2Action->SetPhiMin(SetPhiMinCmd->GetNewDoubleValue(newValue));}
+  
+  if( command == SetPhiMaxCmd )
+     { A2Action->SetPhiMax(SetPhiMaxCmd->GetNewDoubleValue(newValue));}
  
    if( command == SetBeamEnergyCmd )
      { A2Action->SetBeamEnergy(SetBeamEnergyCmd->GetNewDoubleValue(newValue));}

--- a/src/A2PrimaryGeneratorMessenger.cc
+++ b/src/A2PrimaryGeneratorMessenger.cc
@@ -59,17 +59,17 @@ A2PrimaryGeneratorMessenger::A2PrimaryGeneratorMessenger(
   SetTmaxCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   SetTmaxCmd->SetUnitCategory("Energy");
 
-  SetThetaminCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetThetaMin",this);
-  SetThetaminCmd->SetGuidance("Set the minimum particle theta for the phase space generator");
-  SetThetaminCmd->SetParameterName("Thetamin",false);
-  SetThetaminCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-  SetThetaminCmd->SetUnitCategory("Angle");
+  SetThetaMinCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetThetaMin",this);
+  SetThetaMinCmd->SetGuidance("Set the minimum particle theta for the phase space generator");
+  SetThetaMinCmd->SetParameterName("ThetaMin",false);
+  SetThetaMinCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  SetThetaMinCmd->SetUnitCategory("Angle");
 
-  SetThetamaxCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetThetaMax",this);
-  SetThetamaxCmd->SetGuidance("Set the maximum particle theta for the phase space generator");
-  SetThetamaxCmd->SetParameterName("Thetamax",false);
-  SetThetamaxCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-  SetThetamaxCmd->SetUnitCategory("Angle");
+  SetThetaMaxCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetThetaMax",this);
+  SetThetaMaxCmd->SetGuidance("Set the maximum particle theta for the phase space generator");
+  SetThetaMaxCmd->SetParameterName("ThetaMax",false);
+  SetThetaMaxCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  SetThetaMaxCmd->SetUnitCategory("Angle");
 
   SetBeamEnergyCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetBeamEnergy",this);
   SetBeamEnergyCmd->SetGuidance("Set the energy of the photon beam");
@@ -132,8 +132,8 @@ A2PrimaryGeneratorMessenger::~A2PrimaryGeneratorMessenger()
   delete SetTrackCmd;
   delete SetTminCmd;
   delete SetTmaxCmd;
-  delete SetThetaminCmd;
-  delete SetThetamaxCmd;
+  delete SetThetaMinCmd;
+  delete SetThetaMaxCmd;
   delete SetModeCmd;
   delete SetSeedCmd;
   delete SetBeamEnergyCmd;
@@ -175,11 +175,11 @@ void A2PrimaryGeneratorMessenger::SetNewValue(
   if( command == SetTmaxCmd )
      { A2Action->SetTmax(SetTmaxCmd->GetNewDoubleValue(newValue));}
  
-  if( command == SetThetaminCmd )
-     { A2Action->SetThetamin(SetThetaminCmd->GetNewDoubleValue(newValue));}
+  if( command == SetThetaMinCmd )
+     { A2Action->SetThetaMin(SetThetaMinCmd->GetNewDoubleValue(newValue));}
   
-  if( command == SetThetamaxCmd )
-     { A2Action->SetThetamax(SetThetamaxCmd->GetNewDoubleValue(newValue));}
+  if( command == SetThetaMaxCmd )
+     { A2Action->SetThetaMax(SetThetaMaxCmd->GetNewDoubleValue(newValue));}
  
    if( command == SetBeamEnergyCmd )
      { A2Action->SetBeamEnergy(SetBeamEnergyCmd->GetNewDoubleValue(newValue));}

--- a/src/A2PrimaryGeneratorMessenger.cc
+++ b/src/A2PrimaryGeneratorMessenger.cc
@@ -61,13 +61,13 @@ A2PrimaryGeneratorMessenger::A2PrimaryGeneratorMessenger(
 
   SetThetaminCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetThetaMin",this);
   SetThetaminCmd->SetGuidance("Set the minimum particle theta for the phase space generator");
-  SetThetaminCmd->SetParameterName("Tmin",false);
+  SetThetaminCmd->SetParameterName("Thetamin",false);
   SetThetaminCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   SetThetaminCmd->SetUnitCategory("Angle");
 
   SetThetamaxCmd = new G4UIcmdWithADoubleAndUnit("/A2/generator/SetThetaMax",this);
   SetThetamaxCmd->SetGuidance("Set the maximum particle theta for the phase space generator");
-  SetThetamaxCmd->SetParameterName("Tmax",false);
+  SetThetamaxCmd->SetParameterName("Thetamax",false);
   SetThetamaxCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   SetThetamaxCmd->SetUnitCategory("Angle");
 

--- a/src/A2SD.cc
+++ b/src/A2SD.cc
@@ -74,6 +74,8 @@ G4bool A2SD::ProcessHits(G4Step* aStep,G4TouchableHistory*)
   if((mothervolume->GetName().contains("COVR"))&&(aStep->GetPreStepPoint()->GetGlobalTime()>2000*ns))return false;
   else if (aStep->GetPreStepPoint()->GetGlobalTime()>600*ns)return false; 
 
+  if(volume->GetName().contains("PhysiHe")) return false;
+
   // energy correction for non-linearity in plastic scintillators
   //if (volume->GetName() == "PID" ||
   //    volume->GetName() == "TVET" ||
@@ -88,12 +90,11 @@ G4bool A2SD::ProcessHits(G4Step* aStep,G4TouchableHistory*)
   G4Track* track = aStep->GetTrack();
   A2UserTrackInformation* track_info = (A2UserTrackInformation*)
                                         track->GetUserInformation();
-
   //if(volume->GetName().contains("Pb")) G4cout<<volume->GetName()<<" id "<<id <<" "<<mothervolume->GetCopyNo()<<" "<<volume->GetCopyNo()<<" edep "<<edep/MeV<<G4endl;
   if (fhitID[id]==-1){
     //if this crystal has already had a hit
     //don't make a new one, add on to old one.   
-    // G4cout<<"Make hit "<<fCollection<<G4endl;    
+    // G4cout<<"Make hit "<<fCollection<<G4endl;
     A2Hit* myHit = new A2Hit;
     myHit->SetID(id);
     myHit->AddEnergy(edep);


### PR DESCRIPTION
When using the nucleus_fermi plugin of pluto, the output tree now has two pseudo-particles, the first being the beam+target, the second being the beam+quasi-free-target. The first commit forces the code to use the first pseudo-particle to get the beam information (as it has an at-rest target). The second commit adds a carbon nucleus as a target. This should be generalized to include other nuclei in pluto.