### PR TITLE
Patch to compile with Geant4 > 10.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ else()
   find_package(Geant4 REQUIRED)
 endif()
 
+# In Geant4 > 10.6 the preprocessing macros for excluding UI and VIS
+# are not available anymore. Preprocess variable GEANT4_GT_10_6
+# is used to exclude checks on UI and VIS in A2.cc file.
+if ( Geant4_VERSION GREATER_EQUAL 10.6 )
+  message(STATUS "Configuring A2Geant4 for Geant4 version >= 10.6")
+  add_compile_definitions(GEANT4_GT_10_6=1)
+endif()
+
 # define variables
 set(EXT_LIBRARIES)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ August 17, 2018
 ## Installation
 
 ### Dependencies
-* Geant4 10.2/10.3/10.4/10.5
+* Geant4 10.2/10.3/10.4/10.5/10.6/10.7
 * ROOT 5 or 6
 * CMake 3.3
 * Optional: Qt 4 or 5
@@ -69,8 +69,11 @@ tar xvfz geant4.10.04.p02.tar.gz
 Create a build directory (not inside the source directory) and run cmake. Set
 CMAKE_INSTALL_PREFIX to the final installation location and GEANT4_USE_QT to ON
 if you want to use the graphical user interface. Set GEANT4_INSTALL_DATA to ON
-so the large data packages will be downloaded automatically. Set N to the number
-of CPU cores to speed up the compilation process:
+so the large data packages will be downloaded automatically.
+Modern versions of ROOT require at least C++-14. In such cases, you need to
+tell the compiler to use C++-14 standards here as well, by adding
+-DCMAKE_CXX_STANDARD=14 to the cmake line.
+Set N to the number of CPU cores to speed up the compilation process:
 ```
 cd /tmp
 mkdir build

--- a/src/A2.cc
+++ b/src/A2.cc
@@ -17,11 +17,16 @@
 #include "G4UIQt.hh"
 #include "G4Qt.hh"
 #endif
+#ifdef GEANT4_GT_10_6
+#include "G4VisExecutive.hh"
+#include "G4UIExecutive.hh"
+#else
 #ifdef G4VIS_USE
 #include "G4VisExecutive.hh"
 #endif
 #ifdef G4UI_USE
 #include "G4UIExecutive.hh"
+#endif
 #endif
 
 #include "A2DetectorConstruction.hh"


### PR DESCRIPTION
Patch to compile A2Geant4 with Geant4 > 10.6. Only tested up to 10.7, which is the first version of Geant4 that compiles with Ubuntu 22.04. Will try newer Geant4 versions in the future.

The preprocessor macros G4UI_USE and G4VIS_USE are deprecated in 10.6 - these are used in src/A2.cc to test if some headers should be included.
I modify the cmake files to check the geant4 version and define a preprocessor macro GEANT4_GT_10_6. This is then used in src/A2.cc to include the headers.